### PR TITLE
options_local.py file in data directory

### DIFF
--- a/combinato/__init__.py
+++ b/combinato/__init__.py
@@ -13,6 +13,7 @@ except ImportError:
 import os
 if os.path.isfile("options_local.py"):
     from options_local import options, artifact_criteria
+    print("options and artifact_criteria will be read from local options_local.py")
 from .constants import SPIKE_CLUST, SPIKE_MATCHED, SPIKE_MATCHED_2, CLID_UNMATCHED,\
     SIGNS, TYPE_NAMES, TYPE_ART, TYPE_MU, TYPE_SU, TYPE_NO, GROUP_ART, GROUP_NOCLASS,\
     TYPE_NON_NOISE, TYPE_ALL


### PR DESCRIPTION
Incase you would like to use custom options for a certain dataset, you can save them as options_local.py in the data directory. If such a file exists, Combinato will overwrite existing options and artifact_criteria using options_local.py.
