### PR TITLE
mostly tweaking raster plot appearance, (and 'all groups' tab for <5 clusters)

### DIFF
--- a/combinato/guisort/raster_figure.py
+++ b/combinato/guisort/raster_figure.py
@@ -104,7 +104,7 @@ def plot_one_plot(plot, scale, spike_times, onset_times,
     rows, do_plot = create_raster_rows(merged_spike_times,
                                        onset_times.copy())
     if do_plot:
-        plot_convolution(plot, rows, min(2.5, 3/(scale/1.5)))
+        plot_convolution(plot, rows, min(2.5, 10/scale))
     #else:
         #print('Not doing convolution!')
 
@@ -177,6 +177,8 @@ class RasterFigure(MplCanvas):
         if n_stim > 3:
             n_cols = 2
             plot_width = (1 - 8*hgap)/4
+            if len(set(self.frame.paradigm))<2:
+                plot_width *= 2
             n_rows = int((n_stim + 1)/2)
         else:
             n_cols = 1
@@ -197,22 +199,23 @@ class RasterFigure(MplCanvas):
                 row_height + BOTTOM/2 + .01
 
             for shift, paradigm in iterator:
-                pos = (col_shift + hgap + shift, row_bottom,
+                if paradigm in set(self.frame.paradigm):
+                    pos = (col_shift + hgap + shift, row_bottom,
                        plot_width, plot_height)
 
-                plot = figure.add_axes(pos)
-                onset_times = get_onset_times(self.frame, stimulus,
+                    plot = figure.add_axes(pos)
+                    onset_times = get_onset_times(self.frame, stimulus,
                                               daytime, paradigm)
-                if do_numbers:
-                    number = stimulus + 1
-                else:
-                    number = None
-                plot_one_plot(plot, scale, spiketimes, onset_times,
+                    if do_numbers:
+                        number = stimulus + 1
+                    else:
+                        number = None
+                        plot_one_plot(plot, scale, spiketimes, onset_times,
                               self.names[stimulus], self.images[stimulus],
                               paradigm, number)
 
-                if (istim + 1 == n_rows) or (istim + 1 == n_stim):
-                    plot.set_xticks([0, 1000])
-                    plot.set_xticklabels([0, 1000])
+                    if (istim + 1 == n_rows) or (istim + 1 == n_stim):
+                        plot.set_xticks([0, 1000])
+                        plot.set_xticklabels([0, 1000])
 
         self.draw()

--- a/combinato/guisort/sort_widgets.py
+++ b/combinato/guisort/sort_widgets.py
@@ -413,7 +413,7 @@ class AllGroupsFigure(MplCanvas):
 
         ngroup = len(index)
         ncol = 4
-        nrow = int(np.ceil(ngroup/ncol))
+        nrow = max(int(np.ceil(ngroup/ncol)), 2)
         if ncol * nrow < ngroup:
             nrow += 1
 
@@ -444,7 +444,6 @@ class AllGroupsFigure(MplCanvas):
                 ax.set_yticklabels([])
             ax.set_xlim((0, len(x)))
             axes.append(ax)
-
         ylim = (1.2 * total_min, 1.2* total_max)
 
         for ax in axes:

--- a/combinato/guisort/sorter.py
+++ b/combinato/guisort/sorter.py
@@ -117,19 +117,26 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
         import pandas as pd
         from .. import raster_options
 
-        # the following is just an example for one specific experiment
+        # the following should read all standard experiment codes
+        # e.g. 'fn2' or 'ospr3' (string plus one digit)
         base = os.path.basename(self.basedir)
         try:
-            pat = int(base[:3])
-            run = int(base[8:9])
+            pat = base[:3]
+            paradigm = ''
+            for char in base[6:]:
+                paradigm += char
+                if char.isdigit():
+                    break
+
         except ValueError:
             print('Unable to initialize raster meta data')
             return
-        infix = '{:03d}{}{}'.format(pat, raster_options['infix'], run)
+        #infix = '{:03d}{}{}'.format(pat, raster_options['infix'], run)
+        infix = pat+paradigm
         fname_frame = 'frame_{}.h5'.format(infix)
         frame = pd.read_hdf(fname_frame, raster_options['frame_name'])
         meta_prefix = raster_options['meta_prefix']
-        image_path = os.path.join(meta_prefix, infix, infix)
+        image_path = os.path.join(meta_prefix, infix)
 
         # now initialize the data
         self.rasterFigure = RasterFigure(self.centralwidget)


### PR DESCRIPTION
made convolution lines thicker. doubled raster plot width if there is only one paradigm condition (scr or nscr). in group view, if there are <5 clusters, their plots will still only take up the top half of the screen so they don't appear so stretched - whether or not this is actually better is up for debate, but I find it helpful. the raster plot function can handle different paradigm names, specifically different lengths such as fn2 or ospr1.