### PR TITLE
Handle channels which generate no sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 combinato/options.py
 *.pyc
 *.swp
+.DS_Store

--- a/combinato/artifacts/mask_artifacts.py
+++ b/combinato/artifacts/mask_artifacts.py
@@ -226,12 +226,15 @@ def main(fname, concurrent_edges=None, concurrent_bin=None,
             node = h5fid.get_node('/' + sign + '/times')
         except tables.NoSuchNodeError:
             print('{} has no {} spikes'.format(fname, sign))
+            h5fid.close()
             continue
 
         if len(node.shape) == 0:
+            h5fid.close()
             continue
 
         elif node.shape[0] == 0:
+            h5fid.close()
             continue
 
         times = node[:]

--- a/css-simple-clustering
+++ b/css-simple-clustering
@@ -32,15 +32,21 @@ def main():
     sessions = prepare_main(args.datafile, sign, 'index', 0,
                             None, 20000, args.label[0], False, False)
 
-    for name, sign, ses in sessions:
-        cluster_main(name, ses, sign)
+    if (sessions) :
 
-    label = 'sort_{}_{}'.format(sign, args.label[0])
-    outfname = combine_main(args.datafile[0],
-                            [os.path.basename(ses[2]) for ses in sessions],
-                            label)
+        for name, sign, ses in sessions:
+            cluster_main(name, ses, sign)
 
-    groups_main(args.datafile[0], outfname)
+        label = 'sort_{}_{}'.format(sign, args.label[0])
+        outfname = combine_main(args.datafile[0],
+                                [os.path.basename(ses[2]) for ses in sessions],
+                                label)
+
+        groups_main(args.datafile[0], outfname)
+
+    else :
+        print("No spike sessions to sort.")
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Presently if there are no sessions for a particular channel and sign, the css-simple-clustering and mask_artifacts code will crash. Two changes to simply produce no sorting and output files in those cases. This permits easier batching of large number of experiments.