### PR TITLE
Clearing amplitude plot when updating clusters, adding .mat file extension

### DIFF
--- a/combinato/guisort/sort_widgets.py
+++ b/combinato/guisort/sort_widgets.py
@@ -241,6 +241,7 @@ class GroupOverviewFigure(MplCanvas):
         times = [(c.times - self.startTime)/6e4 for c in group.clusters]
 
         if len(times):
+            self.overTimeAx.cla()
             for x, y in zip(times, data):
                 self.overTimeAx.plot(x, y, 'b.',
                                      markersize=options['smallmarker'])
@@ -269,6 +270,7 @@ class GroupOverviewFigure(MplCanvas):
 
         else:
             tstr = ''
+            self.overTimeAx.cla()
         self.cumSpikeAx.set_title(tstr)
 
         # thresholds

--- a/tools/old_format_output.py
+++ b/tools/old_format_output.py
@@ -183,7 +183,7 @@ def parse_args():
                      ' 1 = MU\n 2 = SU\n-1 = Artif.\nRefers to '
                      '"cluster_class"-values 1 and up.\nIgnores Unassigned '
                      '(value 0)'}
-        info_fname = "cluster_info"
+        info_fname = "cluster_info.mat"
         savemat(info_fname, info_dict)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Clearing "Amplitude over time" plot (in the One Group tab) when a new cluster group is selected so that only the current spike amplitudes are visualized. Previously, amplitudes from other, not currently selected cluster groups were also included.
Adding .mat extension to output filename cluster_info.mat.