### PR TITLE
Implemented align-timestamps and do_clean as command-line flags

### DIFF
--- a/combinato/extract/extract.py
+++ b/combinato/extract/extract.py
@@ -49,6 +49,10 @@ def main():
                         help='folder where spikes should be saved')
     parser.add_argument('--refscheme', nargs=1, type=FileType(mode='r'),
                         help='scheme for re-referencing')
+    parser.add_argument('--align-timestamps', action='store_true', 
+                        default=False, help='align timestamps to peaks of extracted spikes')
+    parser.add_argument('--do-clean', action='store_true',
+                        default=False, help='remove spikes that could not be aligned')
     args = parser.parse_args()
 
     if ((args.files is None) and 
@@ -73,7 +77,7 @@ def main():
                  'count': 0,
                  'destination': destination,
                  'scale_factor': args.matfile_scale_factor}]
-        mp_extract(jobs, 1)
+        mp_extract(jobs, 1, align_timestamps=args.align_timestamps, do_clean=args.do_clean)
         return
 
 
@@ -105,7 +109,7 @@ def main():
 
                 jobs.append(jdict)
 
-        mp_extract(jobs, nWorkers)
+        mp_extract(jobs, nWorkers, align_timestamps=args.align_timestamps, do_clean=args.do_clean)
         return
 
 
@@ -162,4 +166,4 @@ def main():
             jobs.append(jdict)
 
 
-    mp_extract(jobs, nWorkers)
+    mp_extract(jobs, nWorkers, align_timestamps=args.align_timestamps, do_clean=args.do_clean)

--- a/combinato/extract/mp_extract.py
+++ b/combinato/extract/mp_extract.py
@@ -65,8 +65,7 @@ def save(q, ctarget):
     print('Save exited')
 
 
-def work(q_in, q_out, count, target):
-
+def work(q_in, q_out, count, target, align_timestamps=False, do_clean=False):
     filters = {}
 
     while count.value < target:
@@ -83,9 +82,9 @@ def work(q_in, q_out, count, target):
 
         filt = filters[ts]
 
-        result = extract_spikes(datatuple[0],
-                                datatuple[1],
-                                ts,  filt)
+        result = extract_spikes(datatuple[0], datatuple[1], ts, filt,
+                                align_timestamps=align_timestamps,
+                                do_clean=do_clean)
 
         q_out.put((job, result))
 
@@ -149,7 +148,7 @@ def read(jobs, q):
     print('Read exited')
 
 
-def mp_extract(jobs, nWorkers):
+def mp_extract(jobs, nWorkers, align_timestamps=False, do_clean=False):
 
     procs = []
 
@@ -166,7 +165,7 @@ def mp_extract(jobs, nWorkers):
 
     # start the worker processes
     for i in range(nWorkers):
-        p = Process(target=work, args=[q_read, q_work, count, ctarget])
+        p = Process(target=work, args=[q_read, q_work, count, ctarget, align_timestamps, do_clean])
         p.daemon = True
         p.start()
         procs.append(p)


### PR DESCRIPTION
This pull request introduces two new command-line flags (--align-timestamps and --do-clean) to the Combinato command css-extract. These flags enable the following:

    --align-timestamps: Align timestamps to the peaks of extracted spikes.
    --do-clean: Remove spikes with unexpected maxima.

These changes address issue [#83](https://github.com/jniediek/combinato/issues/83).