### PR TITLE
Fix  error due to newer matplotlib

### DIFF
--- a/combinato/guisort/sort_widgets.py
+++ b/combinato/guisort/sort_widgets.py
@@ -466,10 +466,8 @@ class AllGroupsFigure(MplCanvas):
             group = self.session.groupsById[gId]
             ax = group.assignAxis
             if ax is not None:
-                while(len(ax.lines)):
-                    ax.lines[0].remove()
-                    if len(ax.lines):
-                        del ax.lines[0]
+                for line in ax.lines:
+                    line.remove()
                 data = group.meandata
                 counts = sum([c.spikes.shape[0] for c in group.clusters])
                 gtype = TYPE_NAMES[group.group_type]


### PR DESCRIPTION
matplotlib has changed how the `ax.lines` list is mutated. This change fixes the error when using combinato with newer versions of matplotlib 

https://discourse.matplotlib.org/t/recommended-way-of-deleting-lines/22526/3