### PR TITLE
Switched to logging API

### DIFF
--- a/combinato/__init__.py
+++ b/combinato/__init__.py
@@ -12,19 +12,34 @@ try:
 except ImportError:
     pass
 
+n_local = 0
 try:
     from local_options import options as local_options
     options.update(local_options)
-    print('Updated {} options by local_options'.format(len(local_options)))
+    n_local = len(local_options)
 except ImportError:
     pass
 
+n_art_local = 0
 try:
     from local_options import artifact_criteria as loc_artifact_criteria
     artifact_criteria.update(loc_artifact_criteria)
-    print('Updated {} artifact criteria from local_options')
+    n_art_local = len(loc_artifact_criteria)
 except ImportError:
     pass
+
+# Configure logging after options are fully merged, before any
+# other combinato modules create their loggers.
+from .util.logging_config import configure_logging  # noqa: E402
+configure_logging(options)
+
+import logging
+_logger = logging.getLogger(__name__)
+
+if n_local:
+    _logger.info('Updated %d options from local_options', n_local)
+if n_art_local:
+    _logger.info('Updated %d artifact criteria from local_options', n_art_local)
 
 from .constants import SPIKE_CLUST, SPIKE_MATCHED, SPIKE_MATCHED_2,\
     CLID_UNMATCHED, SIGNS, TYPE_NAMES, TYPE_ART, TYPE_MU, TYPE_SU,\

--- a/combinato/artifacts/concurrent.py
+++ b/combinato/artifacts/concurrent.py
@@ -6,11 +6,14 @@
 # as they are likely to be artifacts
 
 from __future__ import print_function, division
+import logging
 import os
 import numpy as np
 import tables
 import time
 from .. import NcsFile, h5files, get_regions
+
+logger = logging.getLogger(__name__)
 
 DEBUG = True
 BIN_MS = 3 
@@ -25,8 +28,7 @@ def bincount(ts_beg, ts_end, files, sign='pos'):
         if len(times):
             nch += 1 
             count += (np.histogram(times, bins)[0] > 0)
-            if DEBUG:
-                print('Added {}/{}'.format(i + 1, len(files)))
+            logger.debug('Added %s/%s', i + 1, len(files))
 
     return count, bins, nch 
 
@@ -37,15 +39,15 @@ def _any_from_file(what, fname, sign='pos'):
     try:
         h5file = tables.open_file(fname)
     except IOError as e:
-        print(e.message + ' ' + fname)
+        logger.info('%s %s', e.message, fname)
         times = []
-        failed = True 
-   
+        failed = True
+
     if not failed:
         try:
             times = h5file.get_node('/' + sign + '/times')
         except tables.exceptions.NoSuchNodeError as e:
-            print(e.message + ' ' + fname)
+            logger.info('%s %s', e.message, fname)
             times = []
        
     if what == 'times':
@@ -92,7 +94,7 @@ def write_bincount(folder):
     ncsfiles = get_regions(folder)
 
     if len(ncsfiles) == 0:
-        print('No ncs files found, reading from h5 files')
+        logger.info('No ncs files found, reading from h5 files')
         fid = tables.open_file(files[0], 'r')
         ts_beg = fid.root.thr[0, 0]
         ts_end = fid.root.thr[-1, 1]
@@ -104,7 +106,7 @@ def write_bincount(folder):
                                    ncsfid.num_recs, 
                                    mode='timestamp'))/1000
 
-    print(ts_beg, ts_end, (ts_end - ts_beg)/1000/60)
+    logger.debug('%s %s %s', ts_beg, ts_end, (ts_end - ts_beg)/1000/60)
 
     count, bins, nch = bincount(ts_beg, ts_end, files)
     outfile = tables.open_file(outfname, 'w')

--- a/combinato/artifacts/mask_artifacts.py
+++ b/combinato/artifacts/mask_artifacts.py
@@ -8,6 +8,7 @@ different functions can be called to mark artifacts
 
 
 from __future__ import print_function, division, absolute_import
+import logging
 import os
 from argparse import ArgumentParser
 
@@ -15,6 +16,8 @@ import numpy as np
 import tables
 
 from .. import h5files
+
+logger = logging.getLogger(__name__)
 
 SIGNS = ('pos', 'neg')
 DEBUG = True
@@ -63,8 +66,8 @@ def add_id(artifacts, index, art_id, sign):
             masked = ((index != 0) & (artifacts[:] == 0)).sum()
         else:
             masked = detected
-        print('{}: detected {} {} spikes, masked {} in mode "{}"'.
-              format(id_to_name[art_id], detected, sign, masked, MODE))
+        logger.debug('%s: detected %s %s spikes, masked %s in mode "%s"',
+                    id_to_name[art_id], detected, sign, masked, MODE)
 
     if READONLY:
         return
@@ -81,7 +84,7 @@ def add_id(artifacts, index, art_id, sign):
     else:
         raise ValueError('Unknown artifact storage mode: {}'.format(MODE))
 
-    print('Total: ', (artifacts[:] != 0).sum())
+    logger.debug('Total: %s', (artifacts[:] != 0).sum())
 
 
 def mark_range_detection(times, ranges):
@@ -92,8 +95,8 @@ def mark_range_detection(times, ranges):
     artifacts = np.zeros(times.shape[0], dtype=bool)
     for this_range in ranges:
         idx = (times >= this_range[0]) & (times <= this_range[1])
-        print(this_range, times[0], times[-1])
-        print(idx.sum())
+        logger.debug('%s %s %s', this_range, times[0], times[-1])
+        logger.debug('%s', idx.sum())
         artifacts[idx] |= True
 
     return artifacts, options_ranges['art_id']
@@ -126,7 +129,7 @@ def mark_double_detection(times, spikes, sign):
             kill = i
         artifacts[kill] = True
 
-    print('{} dist < {}'.format((double_idx).sum(), min_dist))
+    logger.debug('%s dist < %s', (double_idx).sum(), min_dist)
     return artifacts, options_double['art_id']
 
 
@@ -146,8 +149,7 @@ def mark_by_diff(times):
         counts, _ = np.histogram(times, bins)
         left_edges_too_many = bins[:-1][counts > max_per_bin]
         # try a loop, but maybe too slow?
-        if DEBUG:
-            print('looping over {} edges'.format(left_edges_too_many.shape[0]))
+        logger.debug('looping over %s edges', left_edges_too_many.shape[0])
         for edge in left_edges_too_many:
             idx = (times >= edge) & (times <= edge + bin_len)
             artifacts[idx] = True
@@ -170,7 +172,7 @@ def bincount_to_edges(concurrent_fname):
     bins = np.arange(start, stop, bin_len)
     cutoff = options_by_bincount['max_frac_ch'] * num_channels
     if DEBUG:
-        print('Using cutoff of {:.0f} channels'.format(cutoff))
+        logger.debug('Using cutoff of %.0f channels', cutoff)
     exclusion_left_edges = bins[:-1][count > cutoff]
     return exclusion_left_edges, bin_len
 
@@ -180,8 +182,8 @@ def mark_by_bincount(times, left_edges, bin_len):
     marks bins with events in too many other channels (specified by counts)
     """
     if DEBUG:
-        print('all channel rejection, looping over {} edges'.
-              format(left_edges.shape[0]))
+        logger.debug('all channel rejection, looping over %s edges',
+                     left_edges.shape[0])
 
     artifacts = np.zeros(times.shape[0], dtype=bool)
 
@@ -225,7 +227,7 @@ def main(fname, concurrent_edges=None, concurrent_bin=None,
         try:
             node = h5fid.get_node('/' + sign + '/times')
         except tables.NoSuchNodeError:
-            print('{} has no {} spikes'.format(fname, sign))
+            logger.info('%s has no %s spikes', fname, sign)
             h5fid.close()
             continue
 
@@ -318,7 +320,7 @@ def parse_args():
         concurrent_edges, concurrent_bin =\
             bincount_to_edges(conc_fname)
     else:
-        print('Not using concurrent spike detection')
+        logger.info('Not using concurrent spike detection')
         concurrent_edges = concurrent_bin = None
 
     if args.file:
@@ -345,7 +347,7 @@ def parse_args():
     # processing (bad because of high I/O)
     for fname in files:
         if DEBUG:
-            print('Starting ' + fname)
+            logger.debug('Starting %s', fname)
         main(fname, concurrent_edges, concurrent_bin, exclude_ranges)
 
 if __name__ == "__main__":

--- a/combinato/cluster/artifacts.py
+++ b/combinato/cluster/artifacts.py
@@ -7,8 +7,11 @@ artifact clusters based on the spike wave forms
 """
 
 from __future__ import print_function, division, absolute_import
+import logging
 import numpy as np
 from .. import options, artifact_criteria
+
+logger = logging.getLogger(__name__)
 
 CRIT = artifact_criteria
 TOLERANCE = 10
@@ -58,7 +61,7 @@ def peak_to_peak(data):
     peak to peak ratio in second half. data: mean spike
     """
     cut = int(data.shape[0]/2)
-    return (data[cut:] - data[0]).ptp()/data.max()
+    return np.ptp(data[cut:] - data[0])/data.max()
 
 
 def artifact_score(data):
@@ -116,7 +119,7 @@ def find_artifacts(spikes, sorted_idx, class_ids, invert=False):
             class_spikes = -class_spikes
         score, reasons, _ = artifact_score(class_spikes)
         if options['Debug']:
-            print(class_id, score, reasons)
+            logger.debug('%s %s %s', class_id, score, reasons)
         artifact_idx[class_idx] = score
         if score:
             artifact_ids.append(class_id)
@@ -131,4 +134,4 @@ def testit():
     data = np.array([[0, 1, 14, 5, 5, 5, 5, 20, 30, 0, 11, 0],
                      [-1, 3, 12, 3, 4, 7, 7, 20, 30, 0, 11, 1]], float)
 
-    print(artifact_score(data))
+    logger.debug('%s', artifact_score(data))

--- a/combinato/cluster/cluster.py
+++ b/combinato/cluster/cluster.py
@@ -6,11 +6,14 @@ main program for spike sorting
 from __future__ import print_function, division, absolute_import
 import os
 import math
+from time import strftime
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
+
 # pylint:   disable=E1101
 from .. import SortingManager, SessionManager, options
-from time import strftime
-from getpass import getuser
 
 import matplotlib.pyplot as mpl
 
@@ -24,8 +27,6 @@ from .plot_temp import plot_temperatures
 from .handle_random_seed import handle_random_seed
 
 
-USER = getuser()
-LOG_FNAME = 'log.txt'
 FIRST_MATCH_FACTOR = options['FirstMatchFactor']
 SEED = None
 
@@ -34,44 +35,35 @@ def features_to_index(features, folder, name, overwrite=True):
     """
     wrapper function
     """
-    #print(f"{strftime('%Y-%m-%d_%H-%M-%S')} features_to_index got called")  # Log function call
-        
+    # logger.debug('features_to_index called: folder=%s, name=%s', folder, name)  # Log function cal
+
     # Handle seed incase the entry point is not argument_parser
     global SEED
     if SEED is None:
         SEED = handle_random_seed()
-        
+
     clu = None
 
     if not overwrite:
         try:
             clu, tree = read_results(folder, name)
-            print('Read clustering results from ' + folder)
-        except IOError:  # as error:
-            print('Starting clustering ')
-            # + error.strerror + ': ' + error.filename)
+            logger.info('Read clustering results from %s', folder)
+        except IOError:
+            logger.info('Starting clustering in %s', folder)
             overwrite = True
 
     if clu is not None:
         if features.shape[0] != clu.shape[1] - 2:
-            print('Read outdated clustering, restarting')
+            logger.info('Read outdated clustering, restarting')
             overwrite = True
 
     if overwrite:
         feat_idx = select_features(features)
-        print('Clustering data in {}/{}'.format(folder, name))
-        
-        cluster_features(features[:, feat_idx], folder, name, SEED)
-        # ret, random_seed_used = cluster_features(features[:, feat_idx], folder, name)
-        # Log_Random_seeds(folder, random_seed_used)
+        logger.info('Clustering data in %s/%s', folder, name)
 
-        now = strftime('%Y-%m-%d_%H-%M-%S')
-        log_fname = os.path.join(folder, LOG_FNAME)
-        with open(log_fname, 'a') as fid_done:
-            fid_done.write('{} {} ran {}\n'.format(now, USER, name))
-            # log random seeds
-            # fid_done.write('Random Seed used: %f\n' % random_seed_used)
-        fid_done.close()
+        cluster_features(features[:, feat_idx], folder, name, SEED)
+
+        logger.info('Clustering run completed: folder=%s, name=%s', folder, name)
 
         clu, tree = read_results(folder, name)
 
@@ -83,7 +75,7 @@ def cluster_step(features, folder, sub_name, overwrite):
     """
     one step in clustering
     """
-    #print(f"{strftime('%Y-%m-%d_%H-%M-%S')} cluster_step got called")  # Log function call
+    # logger.debug('cluster_step called: sub_name=%s', sub_name)  # Log function call
 
     res_idx, tree, used_points = features_to_index(features,
                                                    folder,
@@ -97,9 +89,9 @@ def cluster_step(features, folder, sub_name, overwrite):
         mpl.close(temp_fig)
 
     if options['Debug']:
-        print('Cluster step {} returned'.format(sub_name))
+        logger.debug('Cluster step %s returned', sub_name)
         for clid in np.unique(res_idx):
-            print('{}: {} spikes'.format(clid, (res_idx == clid).sum()))
+            logger.debug('  %d: %d spikes', clid, (res_idx == clid).sum())
 
     return res_idx
 
@@ -108,11 +100,12 @@ def iterative_sorter(features, spikes, n_iterations, name, overwrite=True):
     """
     name is used to generate temporary filenames
     """ 
-    #print(f"{strftime('%Y-%m-%d_%H-%M-%S')} iterative_sorter got called")  # Log function call
+    # logger.debug('iterative_sorter called: name=%s, n_iterations=%d, n_spikes=%d',
+    #              name, n_iterations, features.shape[0]) # Log function call
 
     idx = np.zeros(features.shape[0], np.uint16)
     match_idx = np.zeros(features.shape[0], bool)
-    
+
     for i in range(n_iterations):
 
         # input to clustering are the spikes that have no index so far
@@ -122,20 +115,18 @@ def iterative_sorter(features, spikes, n_iterations, name, overwrite=True):
 
         if sub_idx.sum() < options['MinInputSize']:
             if options['Debug']:
-                print('Stopping iteration, {} spikes left'
-                      .format(sub_idx.sum()))
+                logger.debug('Stopping iteration, %d spikes left', sub_idx.sum())
             break
 
         if options['Debug']:
-            print('Clustering {} spikes'.format(sub_idx.sum()))
+            logger.debug('Clustering %d spikes', sub_idx.sum())
 
         # res_idx contains a number for each cluster generated from clustering
         res_idx = cluster_step(features[sub_idx], name, sub_name, overwrite)
 
         if options['Debug']:
-            print('Iteration {}, new classes: {}'.
-                  format(i, np.unique(res_idx)))
-            print('Iteration {}, old classes: {}'.format(i, np.unique(idx)))
+            logger.debug('Iteration %d, new classes: %s', i, np.unique(res_idx))
+            logger.debug('Iteration %d, old classes: %s', i, np.unique(idx))
 
         clustered_idx = res_idx > 0
         prev_idx_max = idx.max()
@@ -154,14 +145,14 @@ def iterative_sorter(features, spikes, n_iterations, name, overwrite=True):
 
                 if cluster_size < options['MinInputSizeRecluster']:
                     if options['Debug']:
-                        print('Not reclustering cluster {} ({} spikes)'
-                              .format(clid, cluster_size))
+                        logger.debug('Not reclustering cluster %d (%d spikes)',
+                                     clid, cluster_size)
                     continue
 
                 else:
                     if options['Debug']:
-                        print('Reclustering cluster {} ({} spikes)'
-                              .format(clid, cluster_size))
+                        logger.debug('Reclustering cluster %d (%d spikes)',
+                                     clid, cluster_size)
 
                 sub_sub_name = '{}_{:02d}'.format(sub_name, clid)
 
@@ -183,11 +174,11 @@ def sort_spikes(spikes, folder, overwrite=False, sign='pos'):
     """
     function organizes code
     """
-    #print(f"{strftime('%Y-%m-%d_%H-%M-%S')} sort_spikes got called")  # Log function call
+    # logger.debug('sort_spikes called: folder=%s, sign=%s', folder, sign)    # Log function call
 
     n_iterations = options['RecursiveDepth']
     if options['Debug']:
-        print('Recursive depth is {}.'.format(n_iterations))
+        logger.debug('Recursive depth is %d.', n_iterations)
 
     # it is suboptimal that we calculate the features
     # even when reading clusters from disk
@@ -214,7 +205,8 @@ def main(data_fname, session_fname, sign, overwrite=False):
     """
     sort spikes from given session
     """
-    #print(f"{strftime('%Y-%m-%d_%H-%M-%S')} main got called")  # Log function call
+    # logger.debug('main called: data=%s, session=%s, sign=%s',
+    #              data_fname, session_fname, sign)   # Log function call
 
     sort_man = SortingManager(data_fname)
     session = SessionManager(session_fname)
@@ -223,6 +215,11 @@ def main(data_fname, session_fname, sign, overwrite=False):
     sort_idx, match_idx, artifact_ids =\
         sort_spikes(spikes, session.session_dir,
                     overwrite=overwrite, sign=sign)
+
+    # Write random seed to session folder for reproducibility
+    seed_file = os.path.join(session.session_dir, 'random_seed.txt')
+    with open(seed_file, 'a') as f:
+        f.write('{} | {}\n'.format(strftime('%Y-%m-%d_%H-%M-%S'), SEED))
 
     all_ids = np.unique(sort_idx)
 
@@ -243,36 +240,27 @@ def sort_helper(args):
     """
     usual multiprocessing helper, used to un
     """
-    #print(f"{strftime('%Y-%m-%d_%H-%M-%S')} sort_helper got called")  # Log function call
+    # logger.debug('sort_helper called: %s', args)    # Log function call
 
     main(args[0], args[2], args[1], options['overwrite'])
 
 
-def write_options(fname='css-cluster-log.txt'):
+def write_options():
     """
-    save options to log file
+    Log all current clustering options.
     """
-    #print(f"{strftime('%Y-%m-%d_%H-%M-%S')} write_options got called")  # Log function call
+    # logger.debug('write_options called')    # Log function call
 
-    # Remove old session_random_seeds.txt if exists
+    # Remove old session_random_seeds.txt if exists (legacy cleanup)
     if os.path.exists('session_random_seeds.txt'):
         os.remove('session_random_seeds.txt')
-        print('Old session_random_seeds.txt has been deleted.')
-    
-    print('Writing options to file {}'.format(fname))
-    msg = strftime('%Y-%m-%d_%H-%M-%S') + ' ' + USER + '\n'
+        logger.info('Old session_random_seeds.txt has been deleted.')
 
+    logger.info('Clustering options:')
     for key in sorted(options.keys()):
-        if key in ['density_hist_bins', 'cmap']:
+        if key in ('density_hist_bins', 'cmap'):
             continue
-        msg += '{}: {}\n'.format(key, options[key])
-
-    msg += 60 * '-' + '\n'
-
-    with open(fname, 'a') as fid:
-        fid.write(msg)
-
-    fid.close()
+        logger.info('  %s: %s', key, options[key])
 
 
 def test_joblist(joblist):
@@ -280,7 +268,7 @@ def test_joblist(joblist):
     simple test to detect whether the same job is
     requested more than once
     """
-    #print(f"{strftime('%Y-%m-%d_%H-%M-%S')} test_joblist got called")  # Log function call
+    # logger.debug('test_joblist called: %d jobs', len(joblist))   # Log function call
 
     unique_joblist = set(joblist)
     if len(joblist) != len(unique_joblist):
@@ -294,7 +282,7 @@ def test_joblist(joblist):
 
         for key, val in counter.items():
             if val > 1:
-                print('Job {} requested {} times'.format(key, val))
+                logger.warning('Job %s requested %d times', key, val)
         raise ValueError('Duplicate jobs requested')
 
 
@@ -302,7 +290,7 @@ def argument_parser():
     """
     standard argument parsing
     """
-    #print(f"{strftime('%Y-%m-%d_%H-%M-%S')} argument_parser got called")  # Log function call
+    # logger.debug('argument_parser called')   # Log function call
 
     from argparse import ArgumentParser, FileType, ArgumentError
     from multiprocessing import Pool, cpu_count
@@ -348,8 +336,7 @@ def argument_parser():
 
     n_cores = 1 if args.single else cpu_count() + 1
 
-    print('Starting {} jobs with {} workers'.
-          format(len(joblist), n_cores))
+    logger.info('Starting %d jobs with %d workers', len(joblist), n_cores)
 
     write_options()
 

--- a/combinato/cluster/cluster_features.py
+++ b/combinato/cluster/cluster_features.py
@@ -5,8 +5,11 @@ from __future__ import print_function, division, absolute_import
 import os
 import time
 import subprocess
+import logging
 import numpy as np
 #   pylint:disable=E1101
+
+logger = logging.getLogger(__name__)
 
 from .. import options
 
@@ -93,9 +96,8 @@ def cluster_features(features, folder, name, random_seed=None):
         raise Exception('Error in Clustering: ' + name)
 
     if DO_TIMING:
-        with open(os.path.join(folder, 'cluster_log.txt'), 'a') as log_fid:
-            log_fid.write('clustered {} spikes in {:.6f} s'.
-                          format(features.shape[0], dt))
+        logger.debug('clustered: %d spikes in %.3f seconds',
+                    features.shape[0], dt)
 
     if DO_CLEAN:
         _cleanup(cleanname, EXT_TMP)

--- a/combinato/cluster/concatenate.py
+++ b/combinato/cluster/concatenate.py
@@ -7,10 +7,13 @@ for final grouping
 """
 from __future__ import print_function, division, absolute_import
 import os
+import logging
 import numpy as np
 #   pylint: disable=E1101
 import tables
 from multiprocessing import Pool, cpu_count
+
+logger = logging.getLogger(__name__)
 
 import matplotlib.pyplot as mpl
 
@@ -63,9 +66,9 @@ def read_all_info(managers):
         sorted_index[curr_idx:curr_idx+t_size] = man.index
         overfull = (np.diff(sorted_index[:curr_idx+t_size]) == 0).sum()
         if overfull:
-            print(ses, overfull, "ALARM")
+            logger.warning('%s overfull: %s', ses, overfull)
         t_classes = man.classes
-        print("Working on {}".format(man.h5file.filename))
+        logger.info('Working on %s', man.h5file.filename)
         idx = t_classes != 0
         t_classes[idx] += old_max_class
         t_arti = man.artifact_scores.astype(np.int16)
@@ -77,7 +80,7 @@ def read_all_info(managers):
         sorted_info[curr_idx:curr_idx + t_size, COL_MATCH_TYPE] = man.matches
         curr_idx += t_size
         old_max_class = t_classes.max()
-        print('Read {} spikes from {}'.format(t_size, ses))
+        logger.debug('Read %d spikes from %s', t_size, ses)
 
     return sorted_index, sorted_info, np.vstack(artifact_scores)
 
@@ -91,14 +94,14 @@ def write_sorting_file(h5fname, sorted_index, sorted_info, artifacts):
             ('matches', COL_MATCH_TYPE, np.int8))
 
     fid = tables.open_file(h5fname, 'w')
-    print('Writing index')
+    logger.debug('Writing index')
     fid.create_array('/', 'index', sorted_index)
 
     for name, col, atom in data:
-        print('Writing ' + name)
+        logger.debug('Writing %s', name)
         fid.create_array('/', name, sorted_info[:, col].astype(atom))
 
-    print('Writing distance')
+    logger.debug('Writing distance')
     fid.create_array('/', 'distance',
                      np.zeros(sorted_index.shape[0], np.float32))
 
@@ -112,7 +115,7 @@ def write_sorting_file(h5fname, sorted_index, sorted_info, artifacts):
         msg = 'Writing artifacts'
         name = 'artifacts'
 
-    print(msg)
+    logger.debug('%s', msg)
     fid.create_array('/', name, artifacts)
     fid.close()
 
@@ -130,13 +133,13 @@ def collect_sorting(fname, signs, sessions, outfname):
     for ses in sessions:
         ses_mans[ses] = SessionManager(os.path.join(basedir, ses))
 
-    print('Starting read from {}'.format(fname))
+    logger.info('Starting read from %s', fname)
     sorted_index, sorted_info, artifacts = read_all_info(ses_mans)
 
     # write to file so that we can continue from that file
     write_sorting_file(outfname, sorted_index, sorted_info, artifacts)
     for ses, man in ses_mans.items():
-        print('Closed {}'.format(ses))
+        logger.debug('Closed %s', ses)
         del man
 
     return sort_man
@@ -149,8 +152,7 @@ def total_match(fid, all_spikes):
     """
     classes = fid.root.classes[:]
 
-    print('classes: {}, all_spikes: {}'.format(classes.shape,
-                                               all_spikes.shape))
+    logger.debug('classes: %s, all_spikes: %s', classes.shape, all_spikes.shape)
 
     ids, mean_array, stds = get_means(classes, all_spikes)
     if not len(ids):
@@ -172,10 +174,10 @@ def total_match(fid, all_spikes):
 
     for start, stop in zip(starts, stops):
         this_idx = unmatched_idx[start:stop] 
-        print('Calculating match for {} spikes'.
-            format(all_spikes[this_idx].shape[0]))
+        logger.debug('Calculating match for %d spikes',
+                     all_spikes[this_idx].shape[0])
         all_dists = distances_euclidean(all_spikes[this_idx], mean_array)
-        print('all_dists: {}'.format(all_dists.shape))
+        logger.debug('all_dists: %s', all_dists.shape)
 
         all_dists[all_dists > options['SecondMatchFactor'] * stds] = np.inf
         minimizers_idx = all_dists.argmin(1)
@@ -220,8 +222,8 @@ def plot_all_classes(classes, matches, all_spikes, plot_dirname):
     for clnum, clid in enumerate(clids):
         cl_idx = classes == clid
         outname = os.path.join(plot_dirname, 'class_{:03d}.png'.format(clid))
-        print('Plotting {}/{}, {}, {} spikes'.
-               format(clnum + 1, len(clids), plot_dirname, cl_idx.sum()))
+        logger.debug('Plotting %d/%d, %s, %d spikes',
+                     clnum + 1, len(clids), plot_dirname, cl_idx.sum())
         plot_class(fig, xax, xlim, ylim,
                    all_spikes[cl_idx], matches[cl_idx], outname)
 
@@ -271,19 +273,15 @@ def main(fname, sessions, label, do_plot=True):
     basedir = os.path.dirname(fname)
     sorting_dir = os.path.join(basedir, label)
 
-    logfname = os.path.join(basedir, 'log.txt')
-
-    logfid = open(logfname, 'a')
-
     if not os.path.isdir(sorting_dir):
         os.mkdir(sorting_dir)
-        logfid.write('created {}\n'.format(sorting_dir))
+        logger.info('Created directory: %s', sorting_dir)
 
     outfname = os.path.join(sorting_dir, 'sort_cat.h5')
 
     if not options['OverwriteGroups']:
         if os.path.exists(outfname):
-            print(outfname + ' exists already, skipping!')
+            logger.info('%s exists already, skipping!', outfname)
             return None
 
     sort_man = collect_sorting(fname, sign, sessions, outfname)
@@ -317,16 +315,14 @@ def main(fname, sessions, label, do_plot=True):
         fid.root.artifacts[:] = artifacts
         fid.flush()
 
-        # print('New artifacts: {}'.format(fid.root.artifacts))
-
+        logger.debug('New artifacts: %s', fid.root.artifacts)
     if do_plot:
         plot_all_classes(classes, matches, all_spikes, sorting_dir)
-        logfid.write('Plotted classes in {}\n'.format(sorting_dir))
+        logger.info('Plotted classes in %s', sorting_dir)
 
-    print(fid.filename, fid.root.artifacts[:])
+    logger.debug('%s %s', fid.filename, fid.root.artifacts[:])
 
     fid.close()
-    logfid.close()
 
     return outfname
 
@@ -400,7 +396,7 @@ def parse_args():
                 multi_helper((fname, sessions, label, do_groups, do_plots))
         else:
             pool = Pool(cpu_count())
-            print('Starting {} workers to concatenate'.format(cpu_count()))
+            logger.info('Starting %d workers to concatenate', cpu_count())
             pool.map(multi_helper, [(fname, sessions, label,
                                      do_groups, do_plots)
                                     for fname, sessions in jobdict.items()])

--- a/combinato/cluster/create_groups.py
+++ b/combinato/cluster/create_groups.py
@@ -6,11 +6,14 @@ read a total sorting file and group the classes
 """
 from __future__ import absolute_import, print_function, division
 
+import logging
 import tables
 import numpy as np
 from .. import SortingManager, options, CLID_UNMATCHED, GROUP_ART, GROUP_NOCLASS,\
     TYPE_ART, TYPE_NO, TYPE_MU
 from .dist import distance_groups
+
+logger = logging.getLogger(__name__)
 
 
 def create_groups(spikes, classes, clids, sign):
@@ -54,7 +57,7 @@ def create_groups(spikes, classes, clids, sign):
         minimum = dists[gr1, gr2]
         if minimum > crit:
             break
-        print('Merging {} and {}, dist: {:.4f}'.format(gr1, gr2, minimum))
+        logger.debug('Merging %s and %s, dist: %.4f', gr1, gr2, minimum)
         # merge groups 1 and 2 now
         groups[gr1] += groups[gr2]
         del groups[gr2] 
@@ -92,7 +95,7 @@ def main(datafname, sorting_fname, read_only=False):
     idx = sort_fid.root.index[:]
     spikes = man.get_data_by_name_and_index('spikes', idx, sign)
     del man
-    print('Read {} spikes'.format(spikes.shape[0]))
+    logger.debug('Read %s spikes', spikes.shape[0])
     classes = sort_fid.root.classes[:]
     artifacts = sort_fid.root.artifacts[:, :]
     group_arr = artifacts.copy().astype(np.int16)
@@ -101,7 +104,7 @@ def main(datafname, sorting_fname, read_only=False):
     clids = artifacts[~art_idx, 0]
 
     group_arr[art_idx, 1] = GROUP_ART
-    print('Classes: {}'.format(clids))
+    logger.debug('Classes: %s', clids)
 
     groups = create_groups(spikes, classes, clids, sign)
     
@@ -119,17 +122,17 @@ def main(datafname, sorting_fname, read_only=False):
 
         try:
             sort_fid.remove_node('/', 'groups')
-            print('Updating grouping')
+            logger.debug('Updating grouping')
         except tables.NoSuchNodeError:
-            print('Creating grouping')
+            logger.debug('Creating grouping')
 
         sort_fid.create_array('/', 'groups', group_arr)
 
         try:
             sort_fid.remove_node('/', 'groups_orig')
-            print('Updating original grouping')
+            logger.debug('Updating original grouping')
         except tables.NoSuchNodeError:
-            print('Creating original grouping')
+            logger.debug('Creating original grouping')
 
         sort_fid.create_array('/', 'groups_orig', group_arr)
 
@@ -146,18 +149,18 @@ def main(datafname, sorting_fname, read_only=False):
     if not read_only:
         try:
             sort_fid.remove_node('/', 'types')
-            print('Updating types')
+            logger.debug('Updating types')
         except tables.NoSuchNodeError:
-            print('Creating types')
+            logger.debug('Creating types')
 
         sort_fid.create_array('/', 'types', types)
 
         # create backups of types
         try:
             sort_fid.remove_node('/', 'types_orig')
-            print('Updating original types')
+            logger.debug('Updating original types')
         except tables.NoSuchNodeError:
-            print('Storing original types')
+            logger.debug('Storing original types')
 
         sort_fid.create_array('/', 'types_orig', types)
 

--- a/combinato/cluster/define_clusters.py
+++ b/combinato/cluster/define_clusters.py
@@ -6,8 +6,11 @@ given a cluster tree, define clusters and return their index
 """
 
 from __future__ import division, print_function, absolute_import
+import logging
 import numpy as np
 from .. import options
+
+logger = logging.getLogger(__name__)
 
 def find_relevant_tree_points(tree, min_spikes):
     """
@@ -103,7 +106,7 @@ def testit():
     from .cluster_features import testit as test_features
     clu, tree = test_features()
     idx = define_clusters(clu, tree)
-    print(idx)
+    logger.debug('%s', idx)
 
 if __name__ == "__main__":
     testit()

--- a/combinato/cluster/dist.py
+++ b/combinato/cluster/dist.py
@@ -6,9 +6,12 @@ between clusters, groups etc
 
 # pylint: disable=E1101
 from __future__ import division, print_function, absolute_import
+import logging
 import numpy as np
 # import sys
 from .. import options, CLID_UNMATCHED
+
+logger = logging.getLogger(__name__)
 
 
 def distances_euclidean(all_spikes, templates):
@@ -19,7 +22,7 @@ def distances_euclidean(all_spikes, templates):
 
     ret = np.empty((all_spikes.shape[0], templates.shape[0]))
 
-    print('Calculating distances')
+    logger.debug('Calculating distances')
 
     for i, template in enumerate(templates):
         # print(i, end=' ')
@@ -112,7 +115,7 @@ def get_means(classes, all_spikes):
             means.append(meandata.mean(0))
             stds.append(np.sqrt(meandata.var(0).sum()))
             if options['Debug']:
-                print('class {} has stdval: {:.3f}'.format(clid, stds[-1]))
+                logger.debug('class %s has stdval: %.3f', clid, stds[-1])
 
     if not len(means):
         empty = np.array([])

--- a/combinato/cluster/handle_random_seed.py
+++ b/combinato/cluster/handle_random_seed.py
@@ -1,22 +1,18 @@
 # handle_random_seed.py
 
+import logging
 import numpy as np
-from time import strftime
+
+logger = logging.getLogger(__name__)
+
 
 def handle_random_seed(seed=None):
-    
-    log_file='session_random_seed.txt'
-    
-    if(seed is None):
-        # Generate a random seed
+
+    if seed is None:
         random_seed = np.random.random() * 2**32
-        print(f"Generated random seed: {random_seed}")
+        logger.info('Generated random seed: %s', random_seed)
     else:
         random_seed = seed
-        print(f"Prompted random seed: {random_seed}")
-    
-    # Log the random seed to the log file
-    with open(log_file, 'a') as f:
-        f.write('{} | {}\n'.format(strftime('%Y-%m-%d_%H-%M-%S'), random_seed))
-    
+        logger.info('Prompted random seed: %s', random_seed)
+
     return random_seed

--- a/combinato/cluster/plot_temp.py
+++ b/combinato/cluster/plot_temp.py
@@ -1,8 +1,11 @@
 # JN 2015-01-13
 from __future__ import absolute_import, print_function, division
 
+import logging
 import matplotlib.pyplot as mpl
 from .. import options
+
+logger = logging.getLogger(__name__)
 
 
 def plot_temperatures(tree, used_points):

--- a/combinato/cluster/prepare.py
+++ b/combinato/cluster/prepare.py
@@ -5,10 +5,12 @@
 prepare clustering jobs
 """
 from __future__ import print_function, division, absolute_import
+import logging
 import os
 import numpy as np
 from .. import options, DataManager, create_session
 
+logger = logging.getLogger(__name__)
 DEBUG = options['Debug']
 
 
@@ -23,10 +25,10 @@ def make_arguments(filename, sign, mode, start=0,
     start and stop indexes into the spike array, after artifact exclusion
     """
     h5manager = DataManager(filename, cache=['times', 'artifacts'])
-    print('Opened {}'.format(filename))
+    logger.info('Opened %s', filename)
     non_artifact_idx, num_spikes = h5manager.get_non_artifact_index(sign)
     if num_spikes == 0:
-        print('No spikes found!')
+        logger.info('No spikes found!')
         return None
 
     # find start and stop index
@@ -41,7 +43,7 @@ def make_arguments(filename, sign, mode, start=0,
         if add_one:
             start_idx += 1
             stop_idx -= 1
-        print('Converted time to {}-{}'.format(start_idx, stop_idx))
+        logger.info('Converted time to %s-%s', start_idx, stop_idx)
 
     else:
         start_idx = start
@@ -57,7 +59,7 @@ def make_arguments(filename, sign, mode, start=0,
 
     if len(stops) > 1:
         if stops[-1] - stops[-2] < max_nspk_session/5:
-            print('Adjusting stop to have some spikes')
+            logger.debug('Adjusting stop to have some spikes')
             stops[-2] = stops[-1]
             del starts[-1], stops[-1]
 
@@ -81,9 +83,9 @@ def main(fnames, sign, mode, start, stop, max_nspk_session, label,
 
     ret = []
 
-    print('running {} {} {} {} {} {} {} {}'.
-          format(fnames, sign, mode, start, stop, max_nspk_session,
-                 label, 'replace' if replace else 'no replace'))
+    logger.debug('running %s %s %s %s %s %s %s %s',
+                fnames, sign, mode, start, stop, max_nspk_session,
+                label, 'replace' if replace else 'no replace')
 
     for name in fnames:
         jobs = make_arguments(name, sign, mode, start, stop,
@@ -147,7 +149,7 @@ def parse_arguments():
 
     if None not in (args.jobs, args.datafile):
         parser.print_help()
-        print('Supply either list file or data file, not both')
+        logger.info('Supply either list file or data file, not both')
         return
 
     add_one = False
@@ -176,7 +178,7 @@ def parse_arguments():
         if mode == 'index':
             if None in (args.start, args.stop):
                 start_stop = [(0, None)]
-                print('Automatically using all spikes'.format(*start_stop))
+                logger.info('Automatically using all spikes')
             else:
                 start_stop = [(args.start[0], args.stop[0])]
 
@@ -187,7 +189,7 @@ def parse_arguments():
 
         if (mode == 'index') and (None in (args.start, args.stop)):
             start_stop = [(0, None)]
-            print('Automatically using all spikes'.format(*start_stop))
+            logger.info('Automatically using all spikes')
 
         if 'neg' in args.jobs[0]:
             sign = 'neg'

--- a/combinato/cluster/select_features.py
+++ b/combinato/cluster/select_features.py
@@ -2,9 +2,12 @@
 # refactoring
 
 from __future__ import division, print_function, absolute_import
+import logging
 import numpy as np
 import scipy.stats as stats
 from .. import options
+
+logger = logging.getLogger(__name__)
 
 def select_features(features):
     """
@@ -45,4 +48,4 @@ if __name__ == "__main__":
     for i in [2, 4, 6]:
         assert i in features
 
-    print('OK, features: ', features)
+    logger.debug('OK, features: %s', features)

--- a/combinato/cluster/wave_features.py
+++ b/combinato/cluster/wave_features.py
@@ -1,9 +1,12 @@
 # JN 2015-01-11
 
 from __future__ import print_function, division, absolute_import
+import logging
 import numpy as np
 import pywt # scipy doesn't have the flexibility yet
 from .. import options
+
+logger = logging.getLogger(__name__)
 
 WAVELET = pywt.Wavelet(options['Wavelet'])
 OUT_DTYPE = np.float32
@@ -34,7 +37,7 @@ def testit():
     data = np.ones((3, 64)) 
     data[0, :] = np.arange(64)
     data[1, :] = np.linspace(0, 1, 64)
-    print(wavelet_features(data))
+    logger.debug('%s', wavelet_features(data))
     # test successfull 2015-02-10 JN
 
 

--- a/combinato/default_options.py
+++ b/combinato/default_options.py
@@ -92,6 +92,16 @@ options = {
                                      MAX_AMPLITUDE),
     'cmap': cm.hot,
     'overview_ax_ylim': (-150, 150),
+
+    # Logging
+    'LogLevel': 'DEBUG',         # DEBUG, INFO, WARNING, ERROR, CRITICAL
+    'LogDir': '',                # Empty = CWD; set to absolute path to fix
+    'LogToConsole': True,        # StreamHandler to stderr
+    'LogToFile': True,           # FileHandler (one per subsystem)
+    'LogFileMode': 'a',          # Append mode
+    'LogFormat': '%(asctime)s [%(levelname)-7s] %(name)s: %(message)s',
+    'LogDateFormat': '%Y-%m-%d %H:%M:%S',
+
     'Debug': False,
     'histcolor': 'b',
     'histtype': 'stepfilled',

--- a/combinato/extract/extract.py
+++ b/combinato/extract/extract.py
@@ -3,6 +3,10 @@
 
 
 from __future__ import division, print_function, absolute_import
+
+import logging
+logger = logging.getLogger(__name__)
+
 import os
 from argparse import ArgumentParser, FileType
 import tables
@@ -56,7 +60,7 @@ def main():
         (args.jobs is None)):
 
         parser.print_help()
-        print('Supply either files or jobs or matfile.')
+        logger.info('Supply either files or jobs or matfile.')
         return
 
     if args.destination is not None:
@@ -81,7 +85,7 @@ def main():
         with open(args.jobs[0], 'r') as f:
             files = [a.strip() for a in f.readlines()]
         f.close()
-        print('Read jobs from ' + args.jobs[0])
+        logger.info('Read jobs from %s', args.jobs[0])
     else:
         files = args.files
 
@@ -110,7 +114,7 @@ def main():
 
 
     if files[0] is None:
-        print('Specify files!')
+        logger.info('Specify files!')
         return
 
     # construct the jobs
@@ -144,11 +148,11 @@ def main():
         name = os.path.splitext(os.path.basename(f))[0]
         if references is not None:
             reference = references[f]
-            print('{} (re-referenced to {})'.format(f, reference))
+            logger.info('%s (re-referenced to %s)', f, reference)
 
         else:
             reference = None
-            print(name)
+            logger.info(name)
 
         for i in range(len(starts)):
             jdict = {'name': name,

--- a/combinato/extract/extract_spikes.py
+++ b/combinato/extract/extract_spikes.py
@@ -1,3 +1,6 @@
+import logging
+logger = logging.getLogger(__name__)
+
 import numpy as np
 from .interpolate import clean, upsample, downsample, align
 
@@ -13,7 +16,7 @@ options = dict([('threshold_factor', 5),        # 5
 try:
     from local_options import options as local_options
     options.update(local_options)
-    print('Updated {} options by local_options'.format(len(local_options)))
+    logger.info('Updated %s options by local_options', len(local_options))
 except ImportError:
     pass
 
@@ -86,10 +89,10 @@ def extract_spikes(data, times, timestep, filt):
             continue
 
         maxima = np.array(maxima[1:-2])
-        print((np.diff(maxima) < 64).sum())
+        logger.debug('%s', (np.diff(maxima) < 64).sum())
         # make sure maxima are far enough from border of data
         mindex = (maxima >= pre_indices + 5) & (maxima <= len(data) - post_indices - 5)
-        print('Shortening maxima list from {} to {}'.format(len(maxima), mindex.sum()))
+        logger.debug('Shortening maxima list from %s to %s', len(maxima), mindex.sum())
         maxima = maxima[mindex]
         if data_extract is None:
             if options['do_filter']:

--- a/combinato/extract/mp_extract.py
+++ b/combinato/extract/mp_extract.py
@@ -1,6 +1,9 @@
 # JN 2015-02-13 refactoring
 from __future__ import absolute_import, print_function, division
 
+import logging
+logger = logging.getLogger(__name__)
+
 from collections import defaultdict
 from multiprocessing import Process, Queue, Value
 import numpy as np
@@ -38,9 +41,8 @@ def save(q, ctarget):
         this_name_pending_jobs[jcount] = job
 
 
-        print('Job name: {} pending jobs: {} jnow: {}'.format(jname,
-                                                              this_name_pending_jobs.keys(),
-                                                              jcount))
+        logger.debug('Job name: %s pending jobs: %s jnow: %s', jname,
+                    list(this_name_pending_jobs.keys()), jcount)
 
         while last_saved_count[jname] + 1 in this_name_pending_jobs:
             sjob = this_name_pending_jobs[last_saved_count[jname] + 1]
@@ -51,7 +53,7 @@ def save(q, ctarget):
                  openfiles[sjob['name']] = OutFile(sjob['name'], sjob['filename'],
                                                    spoints, sjob['destination'])
 
-            print('saving {}, count {}'.format(sjob['name'], sjob['count']))
+            logger.debug('saving %s, count %s', sjob['name'], sjob['count'])
             openfiles[sjob['name']].write(data)
             all_data[sjob['all_data_ind']] = None
             last_saved_count[jname] = sjob['count']
@@ -62,7 +64,7 @@ def save(q, ctarget):
     for fid in openfiles.values():
         fid.close()
 
-    print('Save exited')
+    logger.info('Save exited')
 
 
 def work(q_in, q_out, count, target):
@@ -89,7 +91,7 @@ def work(q_in, q_out, count, target):
 
         q_out.put((job, result))
 
-    print('Work exited')
+    logger.info('Work exited')
 
 
 def read(jobs, q):
@@ -126,11 +128,11 @@ def read(jobs, q):
         elif 'is_matfile' in job.keys():
             if job['is_matfile']:
                 fname = job['filename']
-                print('Reading from matfile ' + fname)
+                logger.info('Reading from matfile %s', fname)
                 data = read_matfile(fname)
                 if job['scale_factor'] != 1:
-                    print('Rescaling matfile data by {:.4f}'.
-                        format(job['scale_factor']))
+                    logger.debug('Rescaling matfile data by %.4f',
+                                job['scale_factor'])
                     data = (data[0] * job['scale_factor'],
                             data[1],
                             data[2])
@@ -140,13 +142,13 @@ def read(jobs, q):
             if jname not in openfiles:
                 openfiles[jname] = ExtractNcsFile(job['filename'], job['reference'])
 
-            print('Read {} {: 7d} {: 7d}'.format(jname, job['start'], job['stop']))
+            logger.debug('Read %s % 7d % 7d', jname, job['start'], job['stop'])
             data = openfiles[jname].read(job['start'], job['stop'])
             job.update(filename='data_' + jname + '.h5')
 
         q.put((job, data))
 
-    print('Read exited')
+    logger.info('Read exited')
 
 
 def mp_extract(jobs, nWorkers):

--- a/combinato/extract/tools.py
+++ b/combinato/extract/tools.py
@@ -3,6 +3,10 @@ reading and writing data
 """
 # pylint: disable=E1101
 from __future__ import absolute_import, print_function, division
+
+import logging
+logger = logging.getLogger(__name__)
+
 import os
 import numpy as np
 import tables
@@ -26,7 +30,7 @@ def read_matfile(fname):
         sr = DEFAULT_MAT_SR
         insert = 'default'
 
-    print('Using ' + insert + ' sampling rate ({} kHz)'.format(sr/1000.))
+    logger.info('Using %s sampling rate (%s kHz)', insert, sr/1000.)
     ts = 1/sr
     fdata = data['data'].ravel()
     atimes = np.linspace(0, fdata.shape[0]/(sr/1000), fdata.shape[0])
@@ -65,8 +69,8 @@ class ExtractNcsFile(object):
         fdata *= (1e6 * self.ncs_file.header['ADBitVolts'])
 
         if self.ref_file is not None:
-            print('Reading reference data from {}'.
-                format(self.ref_file.filename))
+            logger.debug('Reading reference data from %s',
+                        self.ref_file.filename)
             ref_data = self.ref_file.read(start, stop, 'data')
             fref_data = np.array(ref_data).astype(np.float32)
             fref_data *= 1e6 * self.ref_file.header['ADBitVolts']
@@ -77,9 +81,9 @@ class ExtractNcsFile(object):
 
         err = expected_length - times[-1] + times[0]
         if err != 0:
-            print("Timestep mismatch in {}"
-                  " between records {} and {}: {:.1f} ms"
-                  .format(self.fname, start, stop, err/1e3))
+            logger.info("Timestep mismatch in %s"
+                        " between records %s and %s: %.1f ms",
+                        self.fname, start, stop, err/1e3)
 
         atimes = np.hstack([t + self.timerange for t in times])/1e3
         # MUST NOT USE dictionaries here, because they would persist in memory
@@ -108,7 +112,7 @@ class OutFile(object):
         f.create_earray('/', 'thr', tables.FloatAtom(), (0, 3))
 
         self.f = f
-        print('Initialized ' + fname)
+        logger.info('Initialized %s', fname)
 
     def write(self, data):
         r = self.f.root

--- a/combinato/guioverview/guioverview.py
+++ b/combinato/guioverview/guioverview.py
@@ -7,6 +7,10 @@ Displays overview of ncs files with their extract/sort status
 # JN 2019-01-08 converting to Qt5
 
 from __future__ import print_function, division, absolute_import
+
+import logging
+logger = logging.getLogger(__name__)
+
 import sys
 import os
 
@@ -59,11 +63,11 @@ def load_image(path, entity, fname, img_type, sign=None, label=None):
     if os.path.exists(path_pattern):
         image = QPixmap(QImage(path_pattern))
     else:
-        print(path_pattern + ' does not exist')
+        logger.debug('%s does not exist', path_pattern)
         
     if DEBUG:
         if image is not None:
-            print('Loaded ' + path_pattern)
+            logger.debug('Loaded %s', path_pattern)
 
     return image
 
@@ -172,7 +176,7 @@ class GuiOverview(QMainWindow, Ui_MainWindow):
 
         sorted_channels = sorted(channels)
 
-        print(sorted_channels, label)
+        logger.debug('%s %s', sorted_channels, label)
 
         if DEBUG:
             sorted_channels = sorted_channels[:3]
@@ -444,7 +448,7 @@ class GuiOverview(QMainWindow, Ui_MainWindow):
             msgbox.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
             ret = msgbox.exec_()
             if ret == QMessageBox.Yes:
-                print('Overwriting ' + out_fname)
+                logger.info('Overwriting %s', out_fname)
                 os.rename(out_fname, out_fname + '.bak') 
             else:
                 write = False
@@ -462,7 +466,7 @@ class GuiOverview(QMainWindow, Ui_MainWindow):
         where = 'left'
         which_text = str(self.comboBoxLeftImage.currentText())
         which = IMG_BY_LABEL[which_text]
-        print(which)
+        logger.debug('%s', which)
         self.set_image(where, which)
 
     def set_image_right(self):

--- a/combinato/guioverview/model.py
+++ b/combinato/guioverview/model.py
@@ -4,6 +4,8 @@ class for channel table
 """
 # JN 2014-12-16
 from __future__ import division, print_function, absolute_import
+import logging
+logger = logging.getLogger(__name__)
 from PyQt5.QtCore import Qt, QAbstractTableModel, QModelIndex, QVariant
 
 NCOLS = 16
@@ -90,7 +92,7 @@ class ChannelTableModel(QAbstractTableModel):
         """
         self.beginResetModel()
         self.channels.append(row)
-        print('Added ' + row[0])
+        logger.debug('Added %s', row[0])
         self.endResetModel()
 
     def get_image(self, row, which):

--- a/combinato/guisort/backend.py
+++ b/combinato/guisort/backend.py
@@ -5,6 +5,8 @@ this is the gui sorter backend, doesn't have much functionality actually
 """
 from __future__ import print_function, division, absolute_import
 
+import logging
+logger = logging.getLogger(__name__)
 import os
 import numpy as np
 from .. import SortingManagerGrouped
@@ -16,7 +18,7 @@ class Backend(object):
     gui sorter backend
     """
     def __del__(self):
-        print('Closing session')
+        logger.info('Closing session')
         del self.sorting_manager
         del self.sessions
 
@@ -24,7 +26,7 @@ class Backend(object):
                  start_time=0, stop_time=np.inf):
 
         self.sessions = None
-        print('Openening session {} {}'.format(datafilename, sessionfilename))
+        logger.info('Openening session %s %s', datafilename, sessionfilename)
         self.folder = os.path.dirname(datafilename)
         self.datafile = os.path.basename(datafilename)
         self.sorting_manager = SortingManagerGrouped(datafilename)
@@ -35,7 +37,7 @@ class Backend(object):
         start_idx, stop_idx = self.sorting_manager.\
             get_start_stop_index(self.sign, start_time, stop_time)
 
-        print('Setting index {} to {}'.format(start_idx, stop_idx))
+        logger.debug('Setting index %s to %s', start_idx, stop_idx)
 
         self.sorting_manager.\
             set_sign_times_spikes(self.sign, start_idx, stop_idx)

--- a/combinato/guisort/raster_figure.py
+++ b/combinato/guisort/raster_figure.py
@@ -5,6 +5,8 @@ show resposes in css-gui
 
 from __future__ import print_function, division, absolute_import
 
+import logging
+logger = logging.getLogger(__name__)
 import os
 import numpy as np
 import scipy.signal as signal
@@ -158,7 +160,7 @@ class RasterFigure(MplCanvas):
             stim_name, fname_image = get_stim_info(self.frame, stimulus)
             self.names[stimulus] = stim_name
             fname_image = os.path.join(image_path, fname_image)
-            print(fname_image)
+            logger.debug('%s', fname_image)
             self.images[stimulus] = imread(fname_image)
 
     def update_figure(self, spiketimes, daytime, scale=5,

--- a/combinato/guisort/sessions.py
+++ b/combinato/guisort/sessions.py
@@ -3,6 +3,8 @@ Sessions class for sorting sessions for guisort
 """
 
 from __future__ import print_function, division, absolute_import
+import logging
+logger = logging.getLogger(__name__)
 import numpy as np
 from scipy.io import savemat
 from .cluster import Cluster
@@ -33,14 +35,14 @@ class Sessions(object):
         groups = self.sorting_manager.get_groups()
 
         if GROUP_ART not in groups:
-            print('Adding empty artifact group')
+            logger.info('Adding empty artifact group')
             model = GroupListModel('Artifacts', GROUP_ART, [], TYPE_ART)
             self.groupsById[GROUP_ART] = model
             self.type_table = np.vstack(([GROUP_ART, TYPE_ART],
                                          self.type_table))
 
         if GROUP_NOCLASS not in groups:
-            print('Adding empty noclass group')
+            logger.info('Adding empty noclass group')
             model = GroupListModel('Unassigned', GROUP_NOCLASS, [], TYPE_NO)
             self.groupsById[GROUP_NOCLASS] = model
 
@@ -106,7 +108,7 @@ class Sessions(object):
             if newkey not in keys:
                 self.groupsById[newkey] = GroupListModel(str(newkey),
                                                          newkey, [], TYPE_MU)
-                print('Added group {}'.format(newkey))
+                logger.info('Added group %s', newkey)
                 break
 
         self.type_table = np.vstack((self.type_table, [newkey, TYPE_MU]))
@@ -132,7 +134,7 @@ class Sessions(object):
 
         for pre_new_gid, (size, gid) in enumerate(sizes):
             new_gid = pre_new_gid + 1
-            print("{} -> {} ({})".format(gid, new_gid, size))
+            logger.debug('%s -> %s (%s)', gid, new_gid, size)
             group = self.groupsById[gid] 
             group.name = str(new_gid)
             group.groupId = new_gid

--- a/combinato/guisort/sort_widgets.py
+++ b/combinato/guisort/sort_widgets.py
@@ -4,11 +4,14 @@ file collects widgets that call matplotlib
 """
 
 from __future__ import print_function, division, absolute_import
+import logging
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 import numpy as np
 from matplotlib.backends.backend_qt5agg import\
     FigureCanvasQTAgg as FigureCanvas
+
+logger = logging.getLogger(__name__)
 import matplotlib.pyplot as mpl
 from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec
@@ -155,7 +158,7 @@ class GroupOverviewFigure(MplCanvas):
         if (thresholds is not None) and options['GuiUseThresholdTimeAxis']:
             self.startTime = thresholds[0, 0]
             self.stopTime = thresholds[-1, 0]
-            print('Using times from thresholds')
+            logger.debug('Using times from thresholds')
         else:
             self.startTime = times[0]
             self.stopTime = times[1]
@@ -309,7 +312,7 @@ class GroupOverviewFigure(MplCanvas):
         self.draw()
 
         t2 = time.time()
-        print('Update time: {:.0f} ms'.format((t2 - t1)*1000))
+        logger.debug('Update time: %.0f ms', (t2 - t1) * 1000)
 
     def mark(self, index, histdata=None):
         """
@@ -340,7 +343,7 @@ class GroupOverviewFigure(MplCanvas):
         ts1 = time.time()
         self.draw()
         ts2 = time.time()
-        print('Drawing: {:0.1f} ms'.format((ts2 - ts1)*1000))
+        logger.debug('Drawing: %.1f ms', (ts2 - ts1) * 1000)
 
 
 class ComparisonFigure(MplCanvas):
@@ -469,7 +472,8 @@ class AllGroupsFigure(MplCanvas):
                 while(len(ax.lines)):
                     ax.lines[0].remove()
                     if len(ax.lines):
-                        del ax.lines[0]
+                        # del ax.lines[0]
+                        ax.lines[0].remove()
                 data = group.meandata
                 counts = sum([c.spikes.shape[0] for c in group.clusters])
                 gtype = TYPE_NAMES[group.group_type]

--- a/combinato/guisort/sorter.py
+++ b/combinato/guisort/sorter.py
@@ -6,8 +6,10 @@ from __future__ import print_function, division, absolute_import
 import sys
 import os
 from getpass import getuser
-from time import strftime
 import time
+import logging
+
+logger = logging.getLogger(__name__)
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QMainWindow, QApplication, QListView,
@@ -31,7 +33,6 @@ from .. import options, TYPE_ART, TYPE_MU, TYPE_SU, TYPE_NO
 imageSize = 260
 stylesheet = 'QListView:focus { background-color: rgb(240, 255, 255)}'
 DEBUG = options['Debug']
-LOGFILENAME = 'css_gui_log.txt'
 
 
 class SpikeSorter(QMainWindow, Ui_MainWindow):
@@ -106,12 +107,6 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
         else:
             self.basedir = os.getcwd()
 
-        try:
-            self.logfid = open(LOGFILENAME, 'a')
-        except PermissionError:
-            print('Not logging!')
-            self.logfid = None
-
         self.user = getuser()
 
         self.rasterFigure = None
@@ -137,7 +132,7 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
                     break
 
         except ValueError:
-            print('Unable to initialize raster meta data')
+            logger.error('Unable to initialize raster meta data')
             return
         #infix = '{:03d}{}{}'.format(pat, raster_options['infix'], run)
         infix = pat+paradigm
@@ -195,7 +190,7 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
         self.groupOverviewFigure.save_as_file(str(fout[0]), dpi=300)
 
     def on_actionAutoassign_triggered(self):
-        print(self.sender().text())
+        logger.debug('Auto-assign triggered: %s', self.sender().text())
 
         if self.backend is None:
             return
@@ -204,7 +199,7 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
 
         groupName = str(self.groupComboBox.currentText())
         group = self.backend.sessions.groupsByName[groupName]
-        print('Auto-assigning group {}'.format(group))
+        logger.info('Auto-assigning group %s', group)
 
         if group == '':
             return
@@ -231,7 +226,7 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
                     dist = d
                     minimizer = name
 
-        print('Moving to ' + minimizer + ', distance {:2f}'.format(dist))
+        logger.debug('Moving to %s, distance %.2f', minimizer, dist)
         self.move(self.backend.sessions.groupsByName[minimizer])
         self.updateActiveTab()
         l = self.backend.sessions.groupsByName[minimizer].assignAxis.get_lines()
@@ -265,7 +260,8 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
             folder = ' '.join(item[0:-2])
             datafile = item[-2]
             sortingfile = item[-1]
-            print(folder, datafile, sortingfile)
+            logger.info('Opening session: folder=%s, data=%s, sorting=%s',
+                        folder, datafile, sortingfile)
             item = str(dialog.timesList.selectedItems()[0].text()).split()
             try:
                 start_time_ms = int(item[1])/1000
@@ -274,9 +270,9 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
                 start_time_ms = 0
                 stop_time_ms = np.inf
 
-            print('Opening {} {} {} ({} ms to {} ms)'.
-                  format(folder, datafile, sortingfile,
-                         start_time_ms, stop_time_ms))
+            logger.info('Opening %s %s %s (%.0f ms to %.0f ms)',
+                        folder, datafile, sortingfile,
+                        start_time_ms, stop_time_ms)
 
             datapath = os.path.join(folder, datafile)
             sessionpath = os.path.join(folder, sortingfile)
@@ -348,7 +344,7 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
         if cj + 1 < len(self.job_names):
             self.open_job(cj + 1)
         else:
-            print('Last job open')
+            logger.debug('Last job open')
             return
 
     def actionGotoJob_triggered(self):
@@ -364,9 +360,8 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
 
         if dialog.exec_():
             item = str(dialog.joblist.selectedItems()[0].text())
-            print(item)
             jobid = int(item.split()[0])
-            print(jobid)
+            logger.info('Opening job %d: %s', jobid, item)
             self.open_job(jobid)
 
     def actionOpenJobs_triggered(self):
@@ -406,9 +401,9 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
             self.job_stop_time_ms = stop_time_ms
             job_to_open = 0
 
-            print('Loaded {} jobs from {} {} ({} ms to {} ms)'.
-                  format(len(jobs), self.basedir, jobfile,
-                         start_time_ms, stop_time_ms))
+            logger.info('Loaded %d jobs from %s %s (%.0f ms to %.0f ms)',
+                        len(jobs), self.basedir, jobfile,
+                        start_time_ms, stop_time_ms)
 
             self.open_job(job_to_open)
 
@@ -432,7 +427,8 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
             item = [str(item.text()) for
                     item in dialog.widget.selectedItems()][0]
             start, _, stop, fname = item.split()
-            print(start, stop, fname[1:-2])
+            logger.debug('Selected time range: start=%s, stop=%s, fname=%s',
+                        start, stop, fname[1:-2])
             start, stop = [int(x)/1000 for x in (start, stop)]
             self.backend.set_sign_start_stop('pos', start, stop)
 
@@ -480,18 +476,18 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
         groups = self.backend.sessions.groupsByName
         names = sorted(groups.keys())
         if len(names) <= 3:
-            print('Nothing to move, only groups: {}'.format(names))
+            logger.debug('Nothing to move, only groups: %s', names)
             return
 
         target = names[0]
-        print('Moving everything to group {}'.format(target))
+        logger.info('Moving everything to group %s', target)
 
         for name in names[1:]:
             try:
                 int(name)
                 self.merge_groups(name, target)
             except ValueError:
-                print('not moving {}'.format(name))
+                logger.debug('not moving %s', name)
 
     def actionMerge_triggered(self):
         """
@@ -539,7 +535,7 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
             tgt = shorties[0]
 
         for src in shorties[1:]:
-            print('Merging {} to {}'.format(src, tgt))
+            logger.debug('Merging %d to %d', src, tgt)
             self.merge_groups(src, tgt, mode='by-id', finalize=False)
 
         self.listView.reset()
@@ -581,10 +577,7 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
         ret = msgBox.exec_()
         if ret == QMessageBox.Yes:
             self.backend.sessions.save()
-            now = strftime('%Y-%m-%d_%H-%M-%S')
-            if self.logfid is not None:
-                self.logfid.write('{} {} saved {}\n'.format(now, self.user,
-                                                        self.status_string))
+            logger.info('%s saved %s', self.user, self.status_string)
             self.backend.sessions.dirty = False
 
     def on_actionMarkCluster_triggered(self):
@@ -790,7 +783,7 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
 
         t1 = time.time()
         self.backend.sessions.reorganize_groups()
-        print('Reorganization took {:.3f} seconds'.format(time.time() - t1))
+        logger.debug('Reorganization took %.3f seconds', time.time() - t1)
         self.allGroupsFigureDirty = True
         self.updateGroupsList()
         self.updateActiveTab()
@@ -802,11 +795,12 @@ class SpikeSorter(QMainWindow, Ui_MainWindow):
             return
         datafilename, extn = os.path.splitext(self.backend.datafile)
         outfname = os.path.join(self.backend.folder, datafilename + '.mat')
-        print('Saving to {}'.format(outfname))
+        logger.info('Saving to %s', outfname)
         self.backend.sessions.export_to_matfile(outfname)
 
 
 def except_hook(cls, exception, traceback):
+    logger.critical('Unhandled exception', exc_info=(cls, exception, traceback))
     sys.__excepthook__(cls, exception, traceback)
 
 

--- a/combinato/manager/create_session.py
+++ b/combinato/manager/create_session.py
@@ -3,6 +3,10 @@
 create a new folder for sorting
 """
 from __future__ import print_function, division, absolute_import
+
+import logging
+logger = logging.getLogger(__name__)
+
 import os
 import numpy as np
 import tables
@@ -34,7 +38,7 @@ def create_session(folder, sign, label, index, replace=False):
     data_fname = os.path.join(session_dir, 'sorting.h5')
 
     if os.path.exists(data_fname) and not replace:
-        print('Not replacing ' + data_fname)
+        logger.info('Not replacing %s', data_fname)
 
     h5fid = tables.open_file(data_fname, 'w')
     h5fid.create_array('/', 'index', index.astype(np.uint32))

--- a/combinato/manager/get_clusters.py
+++ b/combinato/manager/get_clusters.py
@@ -3,6 +3,10 @@
 These functions allow for fast and convenient access to clusters
 """
 from __future__ import print_function, division, absolute_import
+
+import logging
+logger = logging.getLogger(__name__)
+
 import numpy as np
 
 def get_data_from_sessions(sorting_man, sessions,\
@@ -61,8 +65,8 @@ def test(fname):
     groups = get_times_from_sessions(sorting_man, ses_names, 'pos')
     groups_full = get_data_from_sessions(sorting_man, ses_names, 'pos',\
             items=['spikes', 'times'])
-    print(groups)
-    print(groups_full)
+    logger.info('%s', groups)
+    logger.info('%s', groups_full)
 
 
 if __name__ == "__main__":

--- a/combinato/manager/manager.py
+++ b/combinato/manager/manager.py
@@ -11,6 +11,9 @@ giving access to clusters, groups etc
 """
 from __future__ import print_function, division, absolute_import
 
+import logging
+logger = logging.getLogger(__name__)
+
 import os
 from glob import glob
 from collections import namedtuple
@@ -53,7 +56,7 @@ class DataManager(object):
             """
             helper
             """
-            print('No {} spikes'.format(sign))
+            logger.debug('No %s spikes', sign)
 
         if cache is None:
             cache = []
@@ -79,7 +82,7 @@ class DataManager(object):
                 artifacts = self._h5file.get_node('/' + sign, 'artifacts')
             except tables.NoSuchNodeError:
                 artifacts = None
-                print('No artifacts defined')
+                logger.debug('No artifacts defined')
 
             if 'spikes' in cache:
                 spikes = spikes[:]
@@ -181,25 +184,25 @@ class SessionManager(object):
             self.classes = self.h5file.root.classes[:]
 
         except tables.NoSuchNodeError:
-            print('No classes')
+            logger.debug('No classes')
             pass
 
         try:
             self.matches = self.h5file.root.matches[:]
         except tables.NoSuchNodeError:
-            print('No matches')
+            logger.debug('No matches')
             pass
 
         try:
             self.artifact_scores = self.h5file.root.artifact_scores[:]
         except tables.NoSuchNodeError:
-            print('No artifacts')
+            logger.debug('No artifacts')
             pass
 
         if True in [x is None for x in
                     (self.classes, self.matches, self.artifact_scores)]:
             self.is_sorted = False
-            print('Unsorted session, not loading sorting data')
+            logger.debug('Unsorted session, not loading sorting data')
         else:
             self.is_sorted = True
 
@@ -219,7 +222,7 @@ class SessionManager(object):
         """
         self._update_node('classes', classes, np.uint16)
         self.classes = classes
-        print('Classes updated')
+        logger.info('Classes updated')
 
     def _update_node(self, name, data, dtype):
         """
@@ -227,9 +230,9 @@ class SessionManager(object):
         """
         try:
             self.h5file.remove_node('/', name)
-            print('Updating ' + name)
+            logger.debug('Updating %s', name)
         except tables.NoSuchNodeError:
-            print('Creating ' + name)
+            logger.debug('Creating %s', name)
 
         self.h5file.create_array('/', name, data.astype(dtype))
 
@@ -344,11 +347,11 @@ class SessionManager(object):
             return fname_full
 
         else:
-            print('File not found: ' + fname_full)
+            logger.info('File not found: %s', fname_full)
             return None
 
     def __del__(self):
-        print('Closing {}'.format(self.session_dir))
+        logger.debug('Closing %s', self.session_dir)
         self.h5file.close()
 
 
@@ -414,12 +417,12 @@ class SortingManager(object):
 
         if DEBUG:
             for sign in SIGNS:
-                print('{} session folders: {}'.
-                      format(sign, self.session_folders[sign]))
-                print('{} session groups: {}'.
-                      format(sign, self.session_groups[sign]))
-                print('{} group types: {}'.
-                      format(sign, self.group_types[sign]))
+                logger.debug('%s session folders: %s',
+                            sign, self.session_folders[sign])
+                logger.debug('%s session groups: %s',
+                            sign, self.session_groups[sign])
+                logger.debug('%s group types: %s',
+                            sign, self.group_types[sign])
 
     def get_group_ids(self, sign='pos'):
         """
@@ -428,7 +431,7 @@ class SortingManager(object):
         if self.group_types is not None:
             return self.group_types[sign][:, 0]
         else:
-            print('called get_group_ids, but no groups loaded')
+            logger.info('called get_group_ids, but no groups loaded')
 
     def get_group_type(self, gid, sign='pos'):
         """
@@ -462,7 +465,7 @@ class SortingManager(object):
         ses = self.groups_h5f.get_node('/' + sign + '/' + session_name)
         # small sanity check:
         idx = (ses[:, 0] == clid).nonzero()[0]
-        print(session_name, idx, group)
+        logger.debug('%s %s %s', session_name, idx, group)
         ses[idx, 1] = group
 
 #        self.groups_h5f.flush()
@@ -570,20 +573,20 @@ def test_one():
     name = sys.argv[1]
     sorting_man = SortingManager(name)
     ses_names = sorting_man.session_groups['pos']
-    print(ses_names)
+    logger.debug('%s', ses_names)
     gids = sorting_man.get_group_ids()
-    print(gids)
+    logger.debug('%s', gids)
     group_data = sorting_man.get_groups_from_sessions(ses_names, 'pos')
 
     for gid, data in group_data.items():
         group_type = sorting_man.get_group_type(gid, 'pos')
-        print(gid, TYPE_NAMES[group_type])
+        logger.debug('%s %s', gid, TYPE_NAMES[group_type])
         for ses_name, clids in data:
-            print(ses_name)
+            logger.debug('%s', ses_name)
             for clid in clids:
                 idx, fname = sorting_man.\
                         get_class_by_session_id(ses_name, clid, 'pos')
-                print(len(idx), fname)
+                logger.debug('%s %s', len(idx), fname)
 
 if __name__ == "__main__":
     test_one()

--- a/combinato/manager/manager_cat.py
+++ b/combinato/manager/manager_cat.py
@@ -5,6 +5,9 @@
 """
 manages spikes and sorting, after concatenation
 """
+import logging
+logger = logging.getLogger(__name__)
+
 import numpy as np
 import tables
 import os
@@ -12,7 +15,7 @@ import os
 from .. import SIGNS, TYPE_NAMES, TYPE_ART, GROUP_NOCLASS, GROUP_ART, NcsFile,\
     TYPE_NON_NOISE, TYPE_ALL
 
-debug = False
+DEBUG = False
 
 class SortingFile(object):
     """
@@ -25,16 +28,16 @@ class SortingFile(object):
         try:
             self.h5fid = tables.open_file(h5fname, 'r+')
         except PermissionError as e:
-            print(e)
+            logger.info('%s', e)
             self.h5fid = tables.open_file(h5fname, 'r')
-            print(f'Opening {h5fname} in read-only mode')
+            logger.info('Opening %s in read-only mode', h5fname)
         self.index = self.h5fid.root.index[:]
         self.classes = self.h5fid.root.classes[:]
         self.groups = self.h5fid.root.groups[:]
         self.types = self.h5fid.root.types[:]
         temp = self.h5fid.get_node_attr('/', 'sign')
-        if debug:
-            print(f'Detected type {type(temp)}')
+        if DEBUG:
+            logger.debug('Detected type %s', type(temp))
         try:
             self.sign = str(temp, 'utf-8')
         except TypeError:
@@ -144,7 +147,7 @@ class SortingManagerGrouped(object):
         try:
             self.h5datafile = tables.open_file(h5fname, 'r')
         except IOError as error:
-            print('Could not initialize {}: {}'.format(h5fname, error))
+            logger.error('Could not initialize %s: %s', h5fname, error)
             self.initialized = False
             return
 
@@ -174,7 +177,7 @@ class SortingManagerGrouped(object):
         try:
             thr = self.h5datafile.root.thr[:, :]
         except tables.exceptions.NoSuchNodeError:
-            print('Extraction thresholds were not saved!')
+            logger.error('Extraction thresholds were not saved!')
             thr = None
         return thr
 
@@ -211,7 +214,7 @@ class SortingManagerGrouped(object):
                 self.header = {'AcqEntName': names[ext]}
                 return
 
-        print('Ncs file not found, no header!')
+        logger.info('Ncs file not found, no header!')
         self.header = None
 
     def init_sorting(self, sorting_folder):
@@ -338,7 +341,7 @@ class SortingManagerGrouped(object):
         shape = self.times[self.sign].shape[0]
         if idx[-1] >= shape:
             idx = idx[idx < shape]
-            print('Shortened index!')
+            logger.debug('Shortened index!')
 
         ret['type'] = gtype
         ret['n_clusters'] = n_clusters
@@ -443,8 +446,7 @@ class Combinato(SortingManagerGrouped):
 
         # quick check if we can do this
         if not os.path.exists(sorting_session):
-            print('Session folder {} '
-                  'not found'.format(sorting_session))
+            logger.info('Session folder %s not found', sorting_session)
             return
 
         super(Combinato, self).__init__(fname)
@@ -452,8 +454,7 @@ class Combinato(SortingManagerGrouped):
         res = self.init_sorting(sorting_session)
 
         if not res:
-            print('Sorting session {} '
-                  'not initialized'.format(sorting_session))
+            logger.info('Sorting session %s not initialized', sorting_session)
         else:
             self.initialized = True
 
@@ -468,19 +469,19 @@ def test(name, label, ts):
     man = SortingManagerGrouped(name)
     if not man.initialized:
         return
-    print('Working on {}, from time {} to {} ({:.1f} min)'
-          .format(name, start, stop, (stop-start)/6e4))
+    logger.info('Working on %s, from time %s to %s (%.1f min)',
+                name, start, stop, (stop - start) / 6e4)
     start_idx, stop_idx = man.get_start_stop_index('pos', start, stop)
-    print('Setting start index: {}, stop index: {}'.
-          format(start_idx, stop_idx))
+    logger.info('Setting start index: %s, stop index: %s',
+                start_idx, stop_idx)
     man.set_sign_times_spikes('pos', start_idx, stop_idx)
     ret = man.init_sorting(os.path.join(os.path.dirname(name), label))
     if not ret:
-        print('Unable to initialize!')
+        logger.info('Unable to initialize!')
         return
-    print(man.sorting.index.shape)
+    logger.info('%s', man.sorting.index.shape)
     groups = man.get_groups()
-    print('Retrieved Groups')
+    logger.info('Retrieved Groups')
     test_gid = groups.keys()[0]
     man.get_group_joined(test_gid)
 
@@ -489,11 +490,11 @@ def test(name, label, ts):
     # iterate through clusters
     all_good = 0
     for k, v in groups.items():
-        print('Group {} type {}'.format(k, TYPE_NAMES[man.get_group_type(k)]))
-        print(v.keys())
+        logger.info('Group %s type %s', k, TYPE_NAMES[man.get_group_type(k)])
+        logger.info('%s', v.keys())
         sumidx = 0
         for clid in v:
-            print('Cluster {} len {}'.format(clid, v[clid]['times'].shape[0]))
+            logger.info('Cluster %s len %s', clid, v[clid]['times'].shape[0])
             sumidx += v[clid]['times'].shape[0]
 
         if man.get_group_type(k) > 0:
@@ -503,19 +504,18 @@ def test(name, label, ts):
         idx2 = man.sorting.get_cluster_index_alt(k)
         assert not (idx1 - idx2).any()
 
-        print('Total index len {} vs {} summed'.
-              format(idx1.shape[0], sumidx))
+        logger.info('Total index len %s vs %s summed', idx1.shape[0], sumidx)
         # assert idx1.shape[0] == sumidx
 
     non_noise_spk = man.get_non_noise_spikes()
     total = man.get_all_spikes()
-    print('Non-noise index has {} elements'.
-          format(non_noise_spk['times'].shape[0]))
+    logger.info('Non-noise index has %s elements',
+                non_noise_spk['times'].shape[0])
     assert non_noise_spk['times'].shape[0] == all_good
 
-    print('Total has {} elements'.format(total['times'].shape[0]))
+    logger.info('Total has %s elements', total['times'].shape[0])
 
     for gid, group in all_groups.items():
-        print('Group {} has {} times, type {} and {} members'.
-              format(gid, group['times'].shape[0],
-                     TYPE_NAMES[group['type']], group['n_clusters']))
+        logger.info('Group %s has %s times, type %s and %s members',
+                    gid, group['times'].shape[0],
+                    TYPE_NAMES[group['type']], group['n_clusters'])

--- a/combinato/plot/plot_cumulative_time.py
+++ b/combinato/plot/plot_cumulative_time.py
@@ -4,6 +4,9 @@
 cumulative spike time plot
 """
 
+import logging
+logger = logging.getLogger(__name__)
+
 import numpy as np
 TEXT_SIZE = 'small'
 

--- a/combinato/plot/plot_extracted.py
+++ b/combinato/plot/plot_extracted.py
@@ -9,6 +9,9 @@ is worth it or not
 
 from __future__ import division, print_function, absolute_import
 
+import logging
+logger = logging.getLogger(__name__)
+
 import os
 import numpy as np
 import tables
@@ -80,7 +83,7 @@ def spikes_overview(dirname, save_fname):
     """
     h5fname = os.path.join(dirname, 'data_' + dirname + '.h5')
     if not os.path.exists(h5fname):
-        print("{} not found".format(h5fname))
+        logger.info('%s not found', h5fname)
         return
 
     fid = tables.open_file(h5fname, 'r')
@@ -90,7 +93,7 @@ def spikes_overview(dirname, save_fname):
         try:
             spikes = fid.get_node('/' + sign + '/spikes')[:, :]
         except tables.NoSuchNodeError as error:
-            print(error)
+            logger.info('%s', error)
             continue
         times = fid.get_node('/' + sign + '/times')[:]
         try:
@@ -98,7 +101,7 @@ def spikes_overview(dirname, save_fname):
             arti_types = np.unique(artifacts)
             n_all_types = len(arti_types)
         except tables.NoSuchNodeError as error:
-            print(error)
+            logger.info('%s', error)
             artifacts = None
             n_all_types = 1
 
@@ -118,7 +121,7 @@ def spikes_overview(dirname, save_fname):
                 idx = artifacts == arti_type
                 n_plots += int(np.ceil(idx.sum()/SPIKES_PER_PLOT))
         if DEBUG:
-            print('{} {}: {} spikes'.format(h5fname, sign, n_spk))
+            logger.debug('%s %s: %s spikes', h5fname, sign, n_spk)
 
         n_rows = int(np.ceil(n_plots/N_COLS))
         fig = make_figure(n_rows)
@@ -129,7 +132,7 @@ def spikes_overview(dirname, save_fname):
 
             if artifacts is not None:
                 current_type = arti_types[type_count]
-                print(current_type)
+                logger.debug('%s', current_type)
                 idx = artifacts == current_type
                 current_spikes = spikes[idx, :]
                 current_times = times[idx]
@@ -147,7 +150,7 @@ def spikes_overview(dirname, save_fname):
                 plot = fig.add_subplot(grid[plot_count])
                 start = start_i * SPIKES_PER_PLOT
                 stop = start + SPIKES_PER_PLOT
-                print(start, stop)
+                logger.debug('%s %s', start, stop)
                 spike_heatmap(plot, current_spikes[start:stop])
                 set_params(plot, x, start == 0)
                 if current_type in artifact_id_to_name:
@@ -191,7 +194,7 @@ def process_file(fname):
     except TypeError:
         entity = 'unknown'
     ncs_fname = os.path.basename(fname)[5:-3]
-    print(ncs_fname)
+    logger.debug(ncs_fname)
     plot_fname = 'spikes_{}_{}'.format(entity, ncs_fname)
     save_fname = os.path.join(OVERVIEW, plot_fname)
     spikes_overview(ncs_fname, save_fname)

--- a/combinato/plot/plot_rawsignal.py
+++ b/combinato/plot/plot_rawsignal.py
@@ -6,6 +6,9 @@ impression of the data quality, movement artifacts and so on
 """
 from __future__ import print_function, division, absolute_import
 
+import logging
+logger = logging.getLogger(__name__)
+
 import os
 import sys
 import time
@@ -46,7 +49,7 @@ def overview_plot(channel):
     plots = []
     fignames = []
 
-    print('Opening %s' % channel)
+    logger.info('Opening %s', channel)
     fid = NcsFile(channel)
     timestep = fid.timestep
     total_time = fid.num_recs * 512 * timestep # in seconds
@@ -171,7 +174,7 @@ def overview_plot(channel):
     subprocess.call(arg)
     for figname in fignames:
         os.remove(figname)
-    print('Completed ' + entname)
+    logger.info('Completed %s', entname)
 
 def main():
     t = time.time()
@@ -187,4 +190,4 @@ def main():
         for ch in channels:
             overview_plot(ch)
 
-    print('Plotting took {:.0f} seconds'.format(time.time() - t))
+    logger.debug('Plotting took %.0f seconds', time.time() - t)

--- a/combinato/plot/plot_sorted.py
+++ b/combinato/plot/plot_sorted.py
@@ -8,6 +8,9 @@ plot all clusters from a channel in one overview figure
 """
 from __future__ import print_function, division, absolute_import
 
+import logging
+logger = logging.getLogger(__name__)
+
 import os
 import numpy as np
 
@@ -52,12 +55,12 @@ def clust_overview_plot(groups, outname):
     row = 0
 
     for gid in sorted(groups.keys()):
-        print(gid, end=' ')
+        logger.debug('%s', gid)
         group = groups[gid]
         gtype = TYPE_NAMES[group['type']]
 
         col = 0
-        print('row {}/{}, col {}/{}'.format(row, nrows, col, NCOLS))
+        logger.debug('row %s/%s, col %s/%s', row, nrows, col, NCOLS)
         plot = fig.add_subplot(grid[row, col])
         # summary plot
         spike_heatmap(plot, group['spikes'])
@@ -71,7 +74,7 @@ def clust_overview_plot(groups, outname):
 
         # label it
         label = '{} {} {}'.format(gid, len(group['times']), gtype)
-        print(label)
+        logger.debug(label)
         pos = (plot.get_xlim()[0], plot.get_ylim()[0])
         plot.text(pos[0], pos[1], label, backgroundcolor='w',
                   va='bottom', fontsize=FONTSIZE)
@@ -80,17 +83,17 @@ def clust_overview_plot(groups, outname):
         col = 1
         for img_name in group['images']:
             try:
-                print(img_name)
+                logger.debug(img_name)
                 image = mpl.imread(img_name)
             except IOError as err:
-                print(err)
+                logger.error('%s', err)
                 continue
 
             if col == NCOLS:
                 col = 0
                 row += 1
 
-            print('row {}/{}, col {}/{}'.format(row, nrows, col, NCOLS))
+            logger.debug('row %s/%s, col %s/%s', row, nrows, col, NCOLS)
             plot = fig.add_subplot(grid[row, col])
             plot.imshow(image)
             plot.axis('off')
@@ -102,7 +105,7 @@ def clust_overview_plot(groups, outname):
 
     # suptitle = '{} {} ... {}'.format(fname, sessions[0], sessions[-1])
     # fig.suptitle(suptitle)
-    print('saving to ' + outname)
+    logger.info('saving to %s', outname)
     fig.savefig(outname, dpi=300)
     mpl.close(fig)
 
@@ -122,7 +125,7 @@ def run_file(fname, savefolder, sign, label):
         entity = 'unknown'
 
     if not manager.initialized:
-        print('could not initialize ' + fname)
+        logger.info('could not initialize %s', fname)
         return
 
     # basedir = os.path.dirname(fname)
@@ -178,5 +181,5 @@ def parse_args():
     label = args.label
 
     for fname in fnames:
-        print(fname)
+        logger.debug(fname)
         run_file(fname, savefolder, sign, label)

--- a/combinato/plot/plot_unit_quality.py
+++ b/combinato/plot/plot_unit_quality.py
@@ -5,6 +5,8 @@
 create a unit overview plots for all units
 """
 from __future__ import division, print_function, absolute_import
+import logging
+logger = logging.getLogger(__name__)
 import os
 
 import numpy as np
@@ -143,7 +145,7 @@ def plot_group(gid, group, group_joined, start_stop, sign,
     just a simple group overview
     """
 
-    print('Plotting group {} ({} clusters)'.format(gid, len(group)))
+    logger.info('Plotting group %s (%s clusters)', gid, len(group))
 
     panels = PANELS
 
@@ -255,12 +257,12 @@ def run_file(fname, sign, label, savefolder):
     run overview plot on one spikes file
     """
 
-    print('Initializing {} {} {}'.format(fname, sign, label))
+    logger.info('Initializing %s %s %s', fname, sign, label)
     # get thresholds
 
     manager = Combinato(fname, sign, label)
     if not manager.initialized:
-        print('Could not initialize {} {}'.format(fname, label))
+        logger.info('Could not initialize %s %s', fname, label)
         return
     thresholds = manager.get_thresholds()
     start = manager.times[sign][0]
@@ -277,11 +279,11 @@ def run_file(fname, sign, label, savefolder):
 
     entity = manager.header['AcqEntName']
 
-    print('Sorting contains {} spikes from {}, duration {}'.
-          format(nspk, entity, dur_str))
+    logger.info('Sorting contains %s spikes from %s, duration %s',
+                nspk, entity, dur_str)
 
     if not manager.initialized:
-        print('could not initialize ' + fname)
+        logger.info('could not initialize %s', fname)
         return
 
 
@@ -332,5 +334,5 @@ def parse_args():
     label = args.label
 
     for fname in fnames:
-        print(fname)
+        logger.debug(fname)
         run_file(fname, sign, label, savefolder)

--- a/combinato/plot/spike_heatmap.py
+++ b/combinato/plot/spike_heatmap.py
@@ -3,6 +3,9 @@
 # function to plot heatmaps of clusters
 from __future__ import absolute_import, division, print_function
 
+import logging
+logger = logging.getLogger(__name__)
+
 import numpy as np
 from matplotlib.pyplot import cm
 

--- a/combinato/util/get_folder_structure.py
+++ b/combinato/util/get_folder_structure.py
@@ -3,6 +3,8 @@
 read out the structure of a sorting folder
 """
 from __future__ import division, print_function, absolute_import
+import logging
+logger = logging.getLogger(__name__)
 import os
 import glob
 from .. import options
@@ -69,12 +71,12 @@ def get_time_files(path):
             try:
                 start, stop = map(int, fid.readline().split())
             except ValueError as error:
-                print(fname, error.message)
+                logger.error('%s %s', fname, error.message)
                 continue
             ret.append((fname, start, stop))
     return ret
 
 
 def test():
-    print(get_relevant_folders(os.getcwd()))
-    print(get_time_files(os.getcwd()))
+    logger.info('%s', get_relevant_folders(os.getcwd()))
+    logger.info('%s', get_time_files(os.getcwd()))

--- a/combinato/util/logging_config.py
+++ b/combinato/util/logging_config.py
@@ -1,0 +1,189 @@
+"""
+Centralized logging configuration for Combinato.
+
+Called once from __init__.py after options are loaded and merged with
+local_options.
+"""
+import datetime
+import logging
+from logging.handlers import RotatingFileHandler
+import os
+import warnings
+
+
+# Subsystems that get their own dedicated log file
+_SUBSYSTEMS = {
+    'extract':    'combinato_extract.log',
+    'cluster':    'combinato_cluster.log',
+    'artifacts':  'combinato_cluster.log',   # shares with cluster
+    'guisort':    'combinato_gui.log',
+    'guioverview': 'combinato_gui.log',      # shares with guisort
+}
+
+_CATCHALL_FNAME = 'combinato.log'
+
+
+class _SubsystemFilter(logging.Filter):
+    """Reject records from subsystems that have their own dedicated log file."""
+    def filter(self, record):
+        name = record.name
+        for prefix in _SUBSYSTEMS:
+            if name == 'combinato.' + prefix or name.startswith('combinato.' + prefix + '.'):
+                return False
+        return True
+
+
+class _ColoredFormatter(logging.Formatter):
+    """Apply ANSI color codes to console output by component.
+
+    Colour scheme
+    ─────────────
+      ·  level tag [DEBUG/INFO/…]  →  by severity
+      ·  logger name                →  #32BDC8 (cyan, no relation to severity)
+      ·  message text               →  by severity (same as level tag)
+
+    File handlers keep the plain Formatter so log files are readable
+    in any editor or pager.
+    """
+    _COLORS = {
+        'DEBUG':    '\033[1;94m',    # bold bright blue
+        'INFO':     '\033[1;92m',    # bold light green
+        'WARNING':  '\033[1;33m',    # bold yellow
+        'ERROR':    '\033[1;31m',    # bold red
+        'CRITICAL': '\033[1;31m',    # bold red
+    }
+    _RESET = '\033[0m'
+    _CYAN = '\033[36m'              # #32BDC8 approximates to ANSI 36
+
+    def format(self, record):
+        # Build message first so getMessage() is called once
+        record.message = record.getMessage()
+        asctime = self.formatTime(record, self.datefmt)
+
+        level_color = self._COLORS.get(record.levelname, '')
+        reset = self._RESET
+
+        # 1) level name inside brackets — coloured by severity
+        level_tag = (f'[{level_color}{record.levelname:<7}{reset}]'
+                     if level_color
+                     else f'[{record.levelname:<7}]')
+
+        # 2) logger name — always cyan
+        name_tag = f'{self._CYAN}{record.name}{reset}'
+
+        # 3) message — coloured by severity
+        msg = (f'{level_color}{record.message}{reset}'
+               if level_color else record.message)
+
+        parts = [f'{asctime} {level_tag} {name_tag}: {msg}']
+
+        # Append exception / stack trace (same logic as Formatter.format)
+        if record.exc_info and not record.exc_text:
+            record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            parts.append(record.exc_text)
+        if record.stack_info:
+            parts.append(self.formatStack(record.stack_info))
+
+        return '\n'.join(parts)
+
+
+def configure_logging(options):
+    """
+    Configure the Python logging framework from the Combinato options dict.
+
+    Must be called AFTER local_options have been merged into the global
+    options dict (i.e., from __init__.py).
+
+    Produces one StreamHandler on the root 'combinato' logger for console
+    output, plus per-subsystem FileHandlers:
+
+        combinato_extract.log   — extraction pipeline
+        combinato_cluster.log   — clustering, artifacts
+        combinato_gui.log       — GUI (guisort, guioverview)
+        combinato.log           — everything else (manager, plot, util, etc.)
+    """
+    # --- Resolve log level ---
+    level_name = options.get('LogLevel', 'INFO').upper()
+    if options.get('Debug', False):
+        warnings.warn(
+            "options['Debug'] is deprecated. "
+            "Set options['LogLevel'] = 'DEBUG' instead.",
+            DeprecationWarning, stacklevel=2,
+        )
+        level_name = 'DEBUG'
+    level = getattr(logging, level_name, logging.INFO)
+
+    # --- Resolve log directory ---
+    ts = datetime.datetime.now().strftime('%Y%m%d')
+    base = options.get('LogDir', '') or os.path.join(os.getcwd(), 'logs')
+    log_dir = os.path.join(base, ts)
+    max_bytes = options.get('LogMaxBytes', 5 * 1024 * 1024)
+    backup_count = options.get('LogBackupCount', 3)
+
+    # --- Build formatter ---
+    fmt = options.get(
+        'LogFormat',
+        '%(asctime)s [%(levelname)-7s] %(name)s: %(message)s',
+    )
+    datefmt = options.get('LogDateFormat', '%Y-%m-%d %H:%M:%S')
+    formatter = logging.Formatter(fmt, datefmt=datefmt)
+
+    # --- Root 'combinato' logger ---
+    root = logging.getLogger('combinato')
+    root.setLevel(level)
+    root.handlers.clear()
+
+    # Console handler (all subsystems share this one) — with colors
+    if options.get('LogToConsole', True):
+        ch = logging.StreamHandler()
+        ch.setLevel(level)
+        ch.setFormatter(_ColoredFormatter(fmt, datefmt=datefmt))
+        root.addHandler(ch)
+
+    if options.get('LogToFile', True):
+        os.makedirs(log_dir, exist_ok=True)
+        mode = options.get('LogFileMode', 'a')
+
+        # Catch-all file handler (filters out subsystem messages)
+        catchall_path = os.path.join(log_dir, _CATCHALL_FNAME)
+        fh_catchall = RotatingFileHandler(
+            catchall_path, mode=mode,
+            maxBytes=max_bytes, backupCount=backup_count,
+        )
+        fh_catchall.setLevel(level)
+        fh_catchall.setFormatter(formatter)
+        fh_catchall.addFilter(_SubsystemFilter())
+        root.addHandler(fh_catchall)
+
+        # Per-subsystem file handlers
+        _configure_subsystem_handlers(level, formatter, log_dir, mode,
+                                      max_bytes, backup_count)
+
+    root.debug('Logging configured: level=%s, dir=%s',
+               level_name, log_dir)
+
+
+def _configure_subsystem_handlers(level, formatter, log_dir, mode,
+                                  max_bytes, backup_count):
+    """
+    Attach a dedicated RotatingFileHandler to each subsystem's top-level logger.
+
+    Propagation stays enabled so console output (via root's StreamHandler)
+    still works.  The _SubsystemFilter on root's catch-all FileHandler
+    prevents records from being duplicated into combinato.log.
+    """
+    # Group subsystem prefixes by their target log file name
+    file_to_loggers = {}
+    for prefix, fname in _SUBSYSTEMS.items():
+        file_to_loggers.setdefault(fname, []).append('combinato.' + prefix)
+
+    for fname, logger_names in file_to_loggers.items():
+        fh = RotatingFileHandler(
+            os.path.join(log_dir, fname), mode=mode,
+            maxBytes=max_bytes, backupCount=backup_count,
+        )
+        fh.setLevel(level)
+        fh.setFormatter(formatter)
+        for name in logger_names:
+            logging.getLogger(name).addHandler(fh)

--- a/combinato/util/tools.py
+++ b/combinato/util/tools.py
@@ -2,11 +2,14 @@
 collection of helper functions
 """
 from __future__ import print_function, division, absolute_import
+import logging
 import os
 from glob import glob
 from collections import defaultdict
 import tables
 from .. import NcsFile, options
+
+logger = logging.getLogger(__name__)
 
 def check_sorted(channel_dirname):
     """
@@ -77,7 +80,7 @@ def get_channels(path, from_h5files=False):
             if os.path.exists(cand):
                 return cand
             else:
-                print('{} not found!'.format(cand))
+                logger.debug('%s not found!', cand)
 
     ret = {}
 
@@ -124,7 +127,7 @@ def get_regions(path):
                 if name[-4:] == '_Ref':
                     name = name[:-4]
                 else:
-                    print('Unknown Region: ' + name[-4:])
+                    logger.debug('Unknown Region: %s', name[-4:])
             
             regions[name].append(ch)
 

--- a/setup_options.py
+++ b/setup_options.py
@@ -24,7 +24,8 @@ def setup():
     elif "win32" in platform:
         binary = 'cluster_64.exe'
     elif "darwin" in platform:
-        binary = 'cluster_maci.exe'
+        # binary = 'cluster_maci.exe'
+        binary = 'cluster_mac_new.exe'
 
     binary = os.path.join(os.getcwd(),'spc', binary)
     try:


### PR DESCRIPTION
## Highlights

Switching to the standard `logging` API for unified, configurable log output (console + log files). Addresses #79.

An example console outputs:

<img width="777" height="143" alt="截屏2026-05-31 12 43 37" src="https://github.com/user-attachments/assets/c56f3f04-8e78-4345-842b-ffa963fa66f3" />


> The levels assignment for different messages might not be proper, and can be further improved.

### File placement
- Each run creates `logs/YYYYMMDD/` subdirectory under CWD — by-day isolation, single GUI session kept together
- **Random seed file** moved from CWD to `session.session_dir/random_seed.txt`, collocated with clustering results

An example path structures:
  ```
  .
  ├── logs
  │   └── 20260531
  │       ├── combinato_cluster.log
  │       ├── combinato_extract.log
  │       ├── combinato_gui.log
  │       └── combinato.log
  ...
  ├── simulation_5
  │   └── sort_pos_simple_0000000_0008967
  │       ├── random_seed.txt
...
  ```

## Changes
Centralized logging infrastructure (`combinato/util/logging_config.py`)

- New `configure_logging(options)` called once from `__init__.py` after options merge
- StreamHandler for console output (colored) + `RotatingFileHandler` for persistent
logs
- 4 subsystem log files: `combinato.log` (catch-all), `combinato_cluster.log`,
`combinato_extract.log`, `combinato_gui.log`
- `_SubsystemFilter` prevents duplication between subsystem and catch-all files
- `_ColoredFormatter` for terminal: level tag + message by severity
(blue/green/yellow/red), logger name in cyan, brackets default


### New configurable options (with defaults)
| Option | Default | Description |
|--------|---------|-------------|
| `LogLevel` | `'DEBUG'` | Console & file verbosity |
| `LogDir` | `''` | Log directory (empty = `CWD/logs/`) |
| `LogToConsole` | `True` | Enable stderr output |
| `LogToFile` | `True` | Enable file output |
| `LogFileMode` | `'a'` | File open mode |
| `LogMaxBytes` | `5_242_880` | Rotate after N bytes |
| `LogBackupCount` | `3` | Number of rotated backups |
